### PR TITLE
Brown's Farms: Disable some types of TNT damage

### DIFF
--- a/Summertime at Brown's Farms/map.xml
+++ b/Summertime at Brown's Farms/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Summertime at Brown's Farms</name>
-<version>1.0.2</version>
+<version>1.0.3</version>
 <objective>Capture the other seven teams' wools.</objective>
 <authors>
     <author uuid="f876b863-1ccd-4ae2-acad-8a09e2209e81"/>
@@ -731,6 +731,10 @@
         </any>
     </deny>
 </damage>
+<disabledamage>
+    <damage ally="true" self="true" enemy="false" other="false">block explosion</damage>
+</disabledamage>
+
 
 <portals>
     <portal yaw="@180" region="red-portal" destination="red-destination" filter="only-red"/>


### PR DESCRIPTION
You and your teammates will no longer take damage from TNT that you place.