### PR TITLE
Zipline 1.0.5

### DIFF
--- a/Zipline/map.xml
+++ b/Zipline/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Zipline</name>
-<version>1.0.4</version>
+<version>1.0.5</version>
 <objective>Hold the flag for 250 seconds to win!</objective>
 <authors>
     <author uuid="1aad55f7-2dea-4f22-85ca-ad9de3a78609"/> <!--  Technodono  -->
@@ -8,11 +8,12 @@
 <rules>
     <rule>Fall damage is disabled!</rule>
 	<rule>You can only respawn when your team doesn't have the flag!</rule>
+	<rule>No camping inside any ziplines!</rule>
 </rules>
 <!--  Tips -->
 <broadcasts>
     <tip after="0m" every="3m">Ziplines transport you really fast in a direction as indicated by the arrows! Use them to get around.</tip>
-	<tip after="90s" every="3m">The flag can spawn at the top or bottom platform... Make sure you split up your team to have a better chance of getting the flag!</tip>
+	<tip after="30s" every="3m">The flag can spawn at the top or bottom platform... Make sure you split up your team to have a better chance of getting the flag!</tip>
 </broadcasts>
 <!--  Teams and Kits  -->
 <teams>
@@ -23,7 +24,6 @@
     <kit id="spawn">
         <item slot="0" unbreakable="true">stone sword</item>
         <item slot="1" unbreakable="true">bow</item>
-        <item slot="2">golden apple</item>
         <item slot="8" amount="16">arrow</item>
         <chestplate unbreakable="true">chainmail chestplate</chestplate>
         <boots unbreakable="true">chainmail boots</boots>
@@ -89,10 +89,10 @@
         </region>
     </apply>
 	<!--  Other regions  -->
-	<cuboid id="spawner1" min="28,15,18" max="32,17,16"/>
-	<cuboid id="spawner2" min="-28,15,18" max="-32,17,16"/>
-	<cuboid id="spawner3" min="28,15,-18" max="32,17,-16"/>
-	<cuboid id="spawner4" min="-28,15,-18" max="-32,17,-16"/>
+	<cuboid id="spawner1" min="28,15.5,18" max="32,17,16"/>
+	<cuboid id="spawner2" min="-28,15.5,18" max="-32,17,16"/>
+	<cuboid id="spawner3" min="28,15.5,-18" max="32,17,-16"/>
+	<cuboid id="spawner4" min="-28,15.5,-18" max="-32,17,-16"/>
 	<!--  Jumpads and Boost lanes  -->
 	<!--  Blue  -->
 	<!--  Middle lane  -->
@@ -350,18 +350,18 @@
 	</all>
 </filters>
 <!--  Spawners  -->
-<spawners max-entities="50" min-delay="4s" max-delay="8s">
+<spawners max-entities="1" min-delay="10s" max-delay="15s">
     <spawner id="arrows1" spawn-region="spawner1" player-region="spawner1">
-        <item amount="2" material="arrow"/>
+        <item amount="1" material="golden apple"/>
     </spawner>
 	<spawner id="arrows2" spawn-region="spawner2" player-region="spawner2">
-        <item amount="2" material="arrow"/>
+        <item amount="1" material="golden apple"/>
     </spawner>
 	<spawner id="arrows3" spawn-region="spawner3" player-region="spawner3">
-        <item amount="2" material="arrow"/>
+        <item amount="1" material="golden apple"/>
     </spawner>
 	<spawner id="arrows4" spawn-region="spawner4" player-region="spawner4">
-        <item amount="2" material="arrow"/>
+        <item amount="1" material="golden apple"/>
     </spawner>
 </spawners>
 <!--  Tools and Misc item stuff  -->
@@ -375,7 +375,7 @@
 	<item>chainmail boots</item>
 	<item>chainmail chestplate</item>
 	<item>cooked beef</item>
-	<item>golden apple</item>
+	<item>arrow</item>
 </itemremove>
 <disabledamage>
 	<!-- Disable fall damage -->
@@ -392,7 +392,8 @@
     <limit>250</limit>
 </score>
 <killreward>
-    <item>golden apple</item>
+    <item amount="6">arrow</item>
+	<item amount="1">golden apple</item>
 </killreward>
 <flags>
     <post id="post" return-time="0s" respawn-time="6s">

--- a/Zipline/map.xml
+++ b/Zipline/map.xml
@@ -1,4 +1,4 @@
-<map proto="1.0.4">
+<map proto="1.4.0">
 <name>Zipline</name>
 <version>1.0.4</version>
 <objective>Hold the flag for 250 seconds to win!</objective>


### PR DESCRIPTION
- added arrows to kill reward
- removed gapples from spawn kit
- changed spawners to gapple drops (every 10-15 seconds), limit is 1 gapple per spawner
- added arrows to item remove
- removed gapples from item remove
-despite numerous efforts to fix this, people would very occasionally get stuck in the top zip-lines...Unfortunately I have tried all possible methods I could to prevent this but it always happened to 1 odd person every match. Hence I have added a rule to try do this... I was thinking maybe have it kill if the player stays in there for more than 3 seconds but I'd like to hear if that's possible