### PR TITLE
Update Zombie Defense to v1.0.6

### DIFF
--- a/Zombie Defense/map.xml
+++ b/Zombie Defense/map.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <map proto="1.4.0">
   <name>Zombie Defense</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <objective>Zombies must destroy the central Villager Monument within 10 minutes. Steves must defend it for 10 minutes.</objective>
   <gamemode>ad</gamemode>
   <authors>
     <author uuid="5ebc601c-82b6-4cd2-88cf-1b5c552b8ace"/> <!--Pe241-->
   </authors>
-  <rules>
-    <rule>Blowing up terrain in your side (Team Griefing-TNT) is disabled.</rule>
-  </rules>
   <teams>
     <team id="zombies" color="dark_green" max="30" show-name-tags="allies" plural="true">Zombies</team>
     <team id="steves" color="gold" max="30" show-name-tags="allies" plural="true">Steves</team>
@@ -55,7 +52,6 @@
     <kit id="players">
       <item slot="0" unbreakable="true">iron_sword</item>
       <item slot="1" unbreakable="true">bow</item>
-      <item slot="2" unbreakable="true">diamond_pickaxe</item>
       <item slot="3" unbreakable="true">iron_axe</item>
       <item slot="5" amount="64">tnt</item>
       <item slot="6" amount="64">redstone_block</item>
@@ -80,6 +76,7 @@
       <potion duration="oo" amplifier="10">regeneration</potion>
     </kit>
     <kit id="zombie" parents="players">
+      <item slot="2" unbreakable="true">diamond_pickaxe</item>      
       <item slot="31" amount="64" damage="13">stained_glass</item>
       <item slot="4" amount="64" damage="3">log</item>
       <item slot="26" amount="64" damage="1">smooth_brick</item>
@@ -89,11 +86,13 @@
       <walk-speed>4</walk-speed>
     </kit>
     <kit id="steve" parents="players" force="true">
+      <item slot="2" unbreakable="true" enchantment="dig speed:5" name="Very Efficient Pickaxe">diamond_pickaxe</item>
       <item slot="31" amount="64" damage="1">stained_glass</item>
       <item slot="4" amount="64">log 2</item>
       <item slot="14" amount="64">tnt</item>
       <item slot="23" amount="64">tnt</item>
       <item slot="26" amount="64">smooth_brick</item>
+      <item slot="29" unbreakable="true" enchantment="dig speed:3" name="Very Efficient Shovel" material="diamond spade"/>
       <helmet locked="true" damage="3" name="`6Steves" material="skull_item"/>
       <chestplate unbreakable="true" color="deb233" material="leather_chestplate" enchantment="protection_explosions:5"/>
       <leggings unbreakable="true" color="deb233" material="leather_leggings" enchantment="protection_explosions"/>
@@ -171,29 +170,6 @@
   <filters>
     <team id="only-zombies">zombies</team>
     <team id="only-steves">steves</team>
-    <not id="explosionprotect">
-      <all>
-        <cause>explosion</cause>
-        <not>
-          <all>
-            <material>tnt</material>
-            <cause>explosion</cause>
-          </all>
-        </not>
-      </all>
-    </not>
-    <not id="noteamgrief-steves">
-      <all>
-        <team>steves</team>
-        <cause>explosion</cause>
-        <not>
-          <all>
-            <material>tnt</material>
-            <cause>explosion</cause>
-          </all>
-        </not>
-      </all>
-    </not>
     <not id="noblowupchest-steves">
       <all>
         <team>steves</team>
@@ -250,7 +226,7 @@
       <rectangle min="-87,73" max="-73,87"/><!--SW-->
       <rectangle min="-87,-73" max="-73,-87"/><!--NW-->
     </union>
-    <cuboid id="steves-only" min="-7,-oo,-7" max="6,24,6"/>
+    <cuboid id="steves-only" min="-7,-oo,-7" max="7,25,7"/>
     <union id="unbreakable">
       <!--Spawner column islands-->
       <!--SE-->
@@ -273,31 +249,7 @@
       <!--White stained glass panel-->
       <cuboid min="-4,46,4" max="4,47,-4"/>
     </union>
-    <complement id="noteamgrief-z">
-      <cuboid min="-87,-oo,-87" max="87,6,87"/>
-      <rectangle min="-67,-67" max="67,67"/>
-      <rectangle min="67,-52" max="87,-30"/>
-      <rectangle min="67,30" max="87,52"/>
-      <rectangle min="30,67" max="52,87"/>
-      <rectangle min="-52,67" max="-30,87"/>
-      <rectangle min="-87,30" max="-67,52"/>
-      <rectangle min="-87,-51" max="-67,-30"/>
-      <rectangle min="-52,-87" max="-30,-67"/>
-      <rectangle min="30,-87" max="52,-67"/>
-    </complement>
     <rectangle id="grass area rec" min="-20,-20" max="20,20"/>
-    <complement id="noteamgrief-s">
-      <region id="steves-side"/>
-      <region id="grass area rec"/>
-    </complement>
-    <complement id="wooden deck">
-      <cuboid min="-28,35,-28" max="28,36,28"/>
-      <cuboid min="-21,35,-21" max="21,36,21"/>
-    </complement>
-    <complement id="fort-roof">
-      <cuboid min="-29,27,-29" max="29,28,29"/>
-      <cuboid min="-20,27,-20" max="20,28,20"/>
-    </complement>
     <union id="zombies-notube">
       <negative>
         <complement>
@@ -311,15 +263,12 @@
         <cuboid min="-8,53,-8" max="8,67,8"/>  
       </negative>
     </union>
-    <union id="noexplosion">
-      <cuboid min="-20,-oo,-20" max="20,21,20"/>
-      <region id="noteamgrief-z"/>
-      <region id="wooden deck"/>
-      <region id="fort-roof"/>
-      <cuboid min="-30,20,-30" max="30,21,30"/>
-      <cuboid min="-30,5,-30" max="30,6,30"/>
-    </union>
     <cuboid id="release" min="-86,50,-86" max="86,51,86"/>
+    <negative id="renewable">
+      <region id="monument"/>
+      <cuboid min="-18,21,-18" max="18,30,18"/>
+      <cuboid min="-20,15,-20" max="20,21,20"/>
+    </negative>
     
     <apply block="never" message="Oops! You can't edit this area!" region="uneditable-area"/>
     <apply enter="only-zombies" message="Hey! This is a `2Zombies`c-only area!" region="zombies-only"/>
@@ -329,10 +278,28 @@
     <apply kit="zombie-castle" filter="only-zombies" region="steves-side-kits"/>
     <apply kit="zombie-cannon" filter="only-zombies" region="cannonkit"/>
     <apply block-break="never" message="Oops! This block is unbreakable!" region="unbreakable"/>
-    <apply block="explosionprotect" region="noexplosion"/>    
-    <apply block="noteamgrief-steves" region="noteamgrief-s"/>
     <apply block="noblowupchest-steves" region="grass area rec"/>
   </regions>
+  <renewables>
+    <renewable avoid-players="4" region="renewable" grow="true" rate="3" sound="false" particles="false">
+      <renew-filter>
+        <not>
+          <any>
+            <material>air</material>
+            <material>water</material>
+            <material>vine</material>
+            <material>skull</material>
+            <material>iron fence</material>
+          </any>
+        </not>
+      </renew-filter>
+      <replace-filter>
+        <any>
+          <material>air</material>
+        </any>
+      </replace-filter>
+    </renewable>
+  </renewables>
   <itemremove>
     <item>iron_sword</item>
     <item>iron_boots</item>
@@ -360,6 +327,7 @@
     <item>wood</item>
     <item>wood_button</item>
     <item>tnt</item>
+    <item>diamond spade</item>
   </itemremove>
   <portals>
     <!--Ground-->


### PR DESCRIPTION
### Change

- Removed grief protect (except chest protect)

- Enabled renewables

- Added Shovel and enchanted pickaxe for steves.