### PR TITLE
Increase spawn items in BlockGlitch

### DIFF
--- a/BlockGlitch/map.xml
+++ b/BlockGlitch/map.xml
@@ -19,15 +19,15 @@
 <players max="50"/>
 <kits>
     <kit id="the-kit" force="true">
-        <item slot="0" material="bedrock"/>
-        <item slot="1" material="bedrock"/>
-        <item slot="2" material="bedrock"/>
-        <item slot="3" material="bedrock"/>
-        <item slot="4" material="bedrock"/>
-        <item slot="5" material="bedrock"/>
-        <item slot="6" material="bedrock"/>
-        <item slot="7" material="bedrock"/>
-        <item slot="8" material="bedrock"/>
+        <item slot="0" amount="6" material="bedrock"/>
+        <item slot="1" amount="9" material="bedrock"/>
+        <item slot="2" amount="6" material="bedrock"/>
+        <item slot="3" amount="9" material="bedrock"/>
+        <item slot="4" amount="6" material="bedrock"/>
+        <item slot="5" amount="9" material="bedrock"/>
+        <item slot="6" amount="6" material="bedrock"/>
+        <item slot="7" amount="9" material="bedrock"/>
+        <item slot="8" amount="6" material="bedrock"/>
         <helmet locked="true">chainmail helmet</helmet>
         <boots locked="true">chainmail boots</boots>
         <!--


### PR DESCRIPTION
This pull request just increases the amount of items in BlockGlitch that would make it more easier to get over walls and a lot less tedious to play the map. Sometimes the item just straight up disappeared and never came back to my inventory lol. This fixes the comment I said in #73 and @StanleyThat approved of these changes