### PR TITLE
Update potion colours in Grand Q-Boid

### DIFF
--- a/Grand qboid/map.xml
+++ b/Grand qboid/map.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <map proto="1.4.0">
 <name>Grand Q*Boid</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <objective>Capture as many hills as you can in 10 minutes.</objective>
 <authors>
     <author uuid="5c79d2c9-a4f0-4343-a84b-e1720f13009b"/>
     <!-- CoWinkKeyDinkInc -->
 </authors>
 <teams>
-    <team id="yellow" color="yellow" max="24">Yellow Team</team>
-    <team id="lime" color="green" max="24">Lime Team</team>
+    <team id="yellow" color="yellow" max="24">Yellow</team>
+    <team id="lime" color="green" max="24">Lime</team>
 </teams>
 <kits>
     <kit id="spawn" force="true">
@@ -18,7 +18,7 @@
         <item slot="2" amount="2">golden apple</item>
         <!-- wool, glass -->
         <item slot="6" amount="32">vine</item>
-        <item slot="7" material="potion" name="Super Jump">
+        <item slot="7" material="potion" damage="43" name="Super Jump">
             <effect duration="15" amplifier="5">jump_boost</effect>
         </item>
         <item slot="8" amount="64">golden carrot</item>
@@ -43,7 +43,7 @@
     </kit>
 </kits>
 <rules>
-    <rule>TNT does not damage yourself or your team mates.</rule>
+    <rule>TNT does not damage yourself or your teammates.</rule>
     <rule>All hills give out one point per two seconds.</rule>
 </rules>
 <spawns>
@@ -77,7 +77,8 @@
         <item amount="12">vine</item>
         <item amount="8">arrow</item>
         <item>golden apple</item>
-        <item material="potion" name="Super Jump">
+        <!-- damage 43 gives potion the jump boost colour, neon green -->
+        <item material="potion" damage="43" name="Super Jump">
             <effect duration="15" amplifier="5">jump_boost</effect>
         </item>
     </kill-reward>


### PR DESCRIPTION
I finally learned how I'm supposed to modify the potion colour, and make something a splash potion.

- Adds damage to jump boost potions so they appear green in game.
- Fixes typo on tip
- Removes "team" from team names 