### PR TITLE
Update Zombie Defense to v1.1.2

### DIFF
--- a/Zombie Defense/map.xml
+++ b/Zombie Defense/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <map proto="1.4.0">
 <name>Zombie Defense</name>
-<version>1.1.1</version>
+<version>1.1.2</version>
 <objective>Zombies must destroy the central Villager Monument within 10 minutes. Steves must defend it for 10 minutes.</objective>
 <gamemode>ad</gamemode>
 <authors>
@@ -534,4 +534,7 @@
 <hunger>
     <depletion>off</depletion>
 </hunger>
+<crafting>
+    <disable>boat</disable>
+</crafting>
 </map>


### PR DESCRIPTION
- Disabled crafting boat to prevent boat glitch