### PR TITLE
Beach Battles 1.1.7

### DIFF
--- a/Beach Battles/map.xml
+++ b/Beach Battles/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Beach Battles</name>
-<version>1.1.6</version>
+<version>1.1.7</version>
 <gamemode>koth</gamemode>
 <objective>Capture and have control over the sand-castles as long as possible!</objective>
 <authors>
@@ -181,13 +181,27 @@
         </region>
     </apply>
     <!-- calculate and add team restrictions -->
+	<apply block-place="only-players" message="You may not place blocks in spawn!">
+        <region> 
+            <union>
+			    <!-- red base -->
+                <cuboid min="50,21,-52" max="56,oo,-67"/>
+				<cuboid min="50,21,-3" max="56,oo,3"/>
+		        <cuboid min="50,21,52" max="56,oo,67"/>
+				<!-- blue base -->
+				<cuboid min="-51,21,-52" max="-57,oo,-67"/>
+				<cuboid min="-51,21,-3" max="-57,oo,3"/>
+		        <cuboid min="-51,21,52" max="-57,oo,67"/>
+            </union>
+        </region>
+    </apply>
     <!-- Finally Calculate void area and other small bits -->
     <apply block-place="only-players" message="You may not bridge into the void!">
         <region> 
             <negative>
                 <union>
                     <rectangle  id="blue-base" min="-57, 67" max="-32,-67"/>
-                    <rectangle  id="red-base" min="57, -67" max="31,67"/>
+                    <rectangle  id="red-base" min="56, -67" max="31,67"/>
                     <rectangle min="32, 68" max="-32,46"/>
                     <rectangle min="32, 11" max="-32,-11"/>
                     <rectangle min="32, -46" max="-32,-68"/>


### PR DESCRIPTION
- prevented blocks from being placed in spawns
- void region was one block too far for the back of red base allowing for blocks to be freely placed there