### PR TITLE
Update Battlefloat to v2.3.2

### DIFF
--- a/Battlefloat/map.xml
+++ b/Battlefloat/map.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <map proto="1.4.0">
 <name>Battlefloat</name>
-<version>2.3.1</version>
+<version>2.3.2</version>
 <authors>
     <author uuid="5ebc601c-82b6-4cd2-88cf-1b5c552b8ace"/> <!--Pe241-->    
 </authors>
@@ -373,4 +373,7 @@
         </region>    
     </portal>
 </portals>
+<world>
+    <timelock>on</timelock>
+</world>
 </map>


### PR DESCRIPTION
- Added timelock module in xml
Now, the timelock by level.dat is ignored due to the bug. This is an attempt to fix that in this map. I don't know if this will work in OCC.