### PR TITLE
Update Zombie Defense to v1.2.2

### DIFF
--- a/Zombie Defense/map.xml
+++ b/Zombie Defense/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <map proto="1.4.0">
 <name>Zombie Defense</name>
-<version>1.2.1</version>
+<version>1.2.2</version>
 <objective>Zombies must destroy the central Villager Monument within 12 minutes. Steves must defend it for 12 minutes.</objective>
 <gamemode>ad</gamemode>
 <authors>
@@ -559,4 +559,7 @@
     <disable>chest</disable>
     <disable>trapped chest</disable>
 </crafting>
+<world>
+    <timelock>on</timelock>
+</world>
 </map>


### PR DESCRIPTION
- Added timelock module in xml
Now, the timelock by level.dat is ignored due to the bug. This is an attempt to fix that in this map. I don't know if this will work in OCC.