### PR TITLE
Fishing Frenzy 1.0.7

### DIFF
--- a/Fishing Frenzy/map.xml
+++ b/Fishing Frenzy/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.4.0">
 <name>Fishing Frenzy</name>
-<version>1.0.6</version>
+<version>1.0.7</version>
+<gamemode>scorebox</gamemode>
 <gamemode>koth</gamemode>
 <objective>Capture and have control over the hills as long as possible!
 Catch fish and score them into your scorebhox for additional points!</objective>
@@ -18,8 +19,8 @@ Catch fish and score them into your scorebhox for additional points!</objective>
     <tip after="30s" every="3m">`e⚠  `7Remember: `6Fish can be scored at the scoreboxes for points!</tip>
     <tip after="0s" every="2m">`e⚠  `7Remember: `6Fish are rewarded for kills!</tip>
 </broadcasts>
+<time>8m</time>
 <score>
-    <limit>750</limit>
     <box filter="only-red" region="red-depot">
         <redeemables>
             <item points="5">RAW_FISH</item>
@@ -60,8 +61,8 @@ Catch fish and score them into your scorebhox for additional points!</objective>
 <kits>
     <kit id="spawn">
         <item amount="1" name="`rKnife" slot="0" unbreakable="true">stone sword</item>
-        <item slot="2" name="`rMusket" unbreakable="true">bow</item>
-        <item slot="1" name="`a`oFisherman's Friend" material="fishing rod">
+        <item slot="1" name="`rMusket" unbreakable="true">bow</item>
+        <item slot="2" name="`a`oFisherman's Friend" material="fishing rod">
             <enchantment level="7">lure</enchantment>
         </item>
         <item slot="3" amount="1">golden apple</item>


### PR DESCRIPTION
- Having the rod in the 2nd slot was confusing for players who were used to 2nd slot bows on oc.tc

- Swapped rod slot with bow... (mentioned above)

- added the scorebox gamemode as is was not in xml

- changed it from 750pt limit to an 8min match as it made the most sense to do that