### PR TITLE
Update Fishing 1.0.8

### DIFF
--- a/Fishing Frenzy/map.xml
+++ b/Fishing Frenzy/map.xml
@@ -1,10 +1,10 @@
 <map proto="1.4.0">
 <name>Fishing Frenzy</name>
-<version>1.0.7</version>
+<version>1.0.8</version>
 <gamemode>scorebox</gamemode>
 <gamemode>koth</gamemode>
-<objective>Capture and have control over the hills as long as possible!
-Catch fish and score them into your scorebhox for additional points!</objective>
+<objective>Capture and have control over the hill as long as possible!
+Catch fish and score them into your scorebox for additional points!</objective>
 <authors>
     <author uuid="1aad55f7-2dea-4f22-85ca-ad9de3a78609" contribution="Map author and creator"/> <!-- Technodono -->
 </authors>
@@ -16,19 +16,21 @@ Catch fish and score them into your scorebhox for additional points!</objective>
     <rule>You should not enter the enemy team's spawns</rule>
 </rules>
 <broadcasts>
-    <tip after="30s" every="3m">`e⚠  `7Remember: `6Fish can be scored at the scoreboxes for points!</tip>
-    <tip after="0s" every="2m">`e⚠  `7Remember: `6Fish are rewarded for kills!</tip>
+    <tip after="1m" every="2m">`e⚠  `7Remember: `6Fish and kill coins can be scored at the scoreboxes for points!</tip>
+    <tip after="0s" every="2m">`e⚠  `7Remember: `6Fish give you 5pts at the scorebox, this is very useful for scoring lots of points!</tip>
 </broadcasts>
 <time>8m</time>
 <score>
     <box filter="only-red" region="red-depot">
         <redeemables>
             <item points="5">RAW_FISH</item>
+			<item points="1">emerald</item>
         </redeemables>
     </box>
     <box filter="only-blue" region="blue-depot">
         <redeemables>
             <item points="5">RAW_FISH</item>
+			<item points="1">emerald</item>
         </redeemables>
     </box>
 </score>
@@ -135,7 +137,7 @@ Catch fish and score them into your scorebhox for additional points!</objective>
     <item>arrow</item>  
 </itemremove>
 <itemkeep>
-    <item>RAW_FISH</item>
+	<item>emerald</item>
 </itemkeep>
 <!-- Boring stuff -->
 <portals>
@@ -155,18 +157,7 @@ Catch fish and score them into your scorebhox for additional points!</objective>
 <killreward>
     <item amount="1">golden_apple</item>
     <item amount="8">arrow</item>
-</killreward>
-<killreward>
-    <filter>
-        <team>red</team>
-    </filter>
-    <item amount="1" damage="0">RAW_FISH</item>
-</killreward>
-<killreward>
-    <filter>
-        <team>blue</team>
-    </filter>
-    <item amount="1" damage="1">RAW_FISH</item>
+	<item name="`aKill coin" lore="`7`oRedeem me at the scorebox to earn 1 point per coin">emerald</item>
 </killreward>
 <!-- Fun game mechnic stuff -->
 <control-points capture-rule="lead" incremental="true" show-progress="true" capture-time="10s" points="2" required="false" neutral-state="true" visual-materials="visual-blocks">


### PR DESCRIPTION
- Wanted to experiment with kills giving less points cause I felt kills giving 5pts (via scoring the fish) was to overpowered

- kill coins created that get given every kill and can be redeemed for 1pt at the scorebox

- kill coins are now kept on death instead of fish which is good cause it gives players a motivation to kill high fish carriers

- fixed small spelling mistakes