### PR TITLE
Changing Spawn Regions (Move Y coordinate 9 to 15)

### DIFF
--- a/Factorio Mainbus/map.xml
+++ b/Factorio Mainbus/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Factorio Mainbus</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <objective>Capture the enemy team's wools! You can get an advantage on this match by using potions that are located on structures!</objective>
 <authors>
     <author uuid="5d1191a6-9114-493e-9867-d31cdd86a603" contribution="Main concept and XML"/> <!-- JTBC -->
@@ -8,7 +8,7 @@
     <author uuid="fe3608b7-d105-4029-8800-34b3147065b6" contribution="Wool room design and balancing"/> <!-- rockymine -->
 </authors>
 <contributors>
-    <contributor uuid="621b2aa8-4e5f-4ed8-bd36-0ae2f8952a06" contribution="Feedback, balancing on Factorio Gridbase"/> <!-- Strangey -->
+    <contributor uuid="621b2aa8-4e5f-4ed8-bd36-0ae2f8952a06" contribution="Feedback, Balancing on Factorio Gridbase"/> <!-- Strangey -->
 </contributors>
 <broadcasts>
     <tip after="1s" every="4m">You can find a potion spawner on most of the structures. Obtain potions to get an advantage for this match!</tip>
@@ -138,12 +138,12 @@
     </default>
     <spawn team="blue" kit="initial-blue-kit">
         <region yaw="180">
-            <point>53,9,-66.5</point>
+            <point>53,15,-66.5</point>
         </region>
     </spawn>
     <spawn team="red" kit="initial-red-kit">
         <region yaw="0">
-            <point>53,9,-227.5</point>
+            <point>53,15,-227.5</point>
         </region>
     </spawn>
 </spawns>


### PR DESCRIPTION
Thanks for clearing my XML. however, there is one issue with spawn regions when I test locally.
The issue is spawn location on each team. I intentionally set it higher (15) than floor (9) because I want to activate the filter "enter-blue" and "enter-red" that are related to the time-based spawn kit.  If I don't set up the y coordinate to 15, It won't activate the filter, and kit revising won't happen. 

However, when I test locally, I don't find any issue without this. Again, Thanks for clearing the XML :D