### PR TITLE
Update Coreo's map.xml

### DIFF
--- a/dtcm/standard/coreo/map.xml
+++ b/dtcm/standard/coreo/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Coreo</name>
-<version>1.1.0</version>
+<version>1.1.1</version>
 <objective>Destroy and leak the enemy's coreos!</objective>
 <authors>
     <author uuid="345e7c1e-2b0f-4b6e-be83-5494ec6d4e7d"/> <!-- ElDanii -->
@@ -8,9 +8,17 @@
     <author uuid="55cb168a-e28f-49e5-a853-8268093926c8"/> <!-- 0uzi -->
 </authors>
 <contributors>
-    <contributor uuid="5c79d2c9-a4f0-4343-a84b-e1720f13009b" contribution="XML support and suggestions"/> <!-- CoWinkKeyDinkInc, thanks! -->
+    <contributor uuid="5c79d2c9-a4f0-4343-a84b-e1720f13009b" contribution="XML Support and suggestions"/> <!-- CoWinkKeyDinkInc, thanks! -->
 </contributors>
 <gamemode>dtc</gamemode>
+<broadcasts>
+    <tip after="5s">`e`l[Tip] `fGet `loreos `ffrom kill reward.</tip>
+    <tip after="10s">`e`l[Tip] `fBy using `ltwo (2) oreos `fyou can craft a `6Haste III`f potion!</tip>
+    <tip after="50s">`e`l[!] `fRemember to share oreos with your teammates!</tip>
+    <tip after="300s">`e`l[!] `fOreos.. hmm yummy!</tip>
+    <tip after="2m" every="2m">`e`l[Tip] `fGet `loreos `ffrom killrewards.</tip>
+    <tip after="2m" every="2m">`e`l[Tip] `fCraft a `6Haste III`f potion by using `ltwo (2) oreos`f.</tip>
+</broadcasts>
 <teams>
     <team id="cookie-team" color="dark gray" max="12">Cookies</team>
     <team id="cream-team" color="white" max="12">Cream</team>
@@ -25,6 +33,7 @@
             <skin>ewogICJ0aW1lc3RhbXAiIDogMTYzNjE4NTUzOTUwMiwKICAicHJvZmlsZUlkIiA6ICI5NzEwNDJmNjVlZmI0MTdjOGUwZGY3NmMzZDgwYzBhNCIsCiAgInByb2ZpbGVOYW1lIiA6ICJBbWVyaWNhbk9yZW8iLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2NhNDIxY2RlMzdjYmNlOTk2YTlmMzNhODk3ODkzZTk3ZDcwN2Q5Yjc2M2Q1MmY1ZmFlNjA0M2E2MzEzYjBjYiIKICAgIH0KICB9Cn0=</skin>
         </head>
         <item slot="8" material="cookie" name="`6Cookie" lore="`7Not better than an oreo" amount="32"/>
+        <potion duration="oo">night vision</potion>
         <potion duration="3" amplifier="2">resistance</potion> <!-- Prevent spawnkill -->
         <potion duration="2" amplifier="1">strength</potion> <!-- Prevent spawnkill -->
         <potion duration="3" amplifier="1">haste</potion> <!-- Prevent blockspawn -->
@@ -123,9 +132,9 @@
 <kill-rewards>
     <kill-reward>
       <kit>
-        <potion duration="2">night vision</potion>
         <potion duration="3" amplifier="2">regeneration</potion>
         <potion duration="30">absorption</potion>
+        <potion duration="1">saturation</potion>
       </kit>
     </kill-reward>
 </kill-rewards>
@@ -140,7 +149,7 @@
 <crafting>
     <shapeless>  <!-- Haste II potion recipe -->
         <result material="potion" damage="8194" name="`fPotion of Haste">
-            <effect duration="30s" amplifier="2">haste</effect>
+            <effect duration="30s" amplifier="3">haste</effect>
             <effect duration="30s" amplifier="1">fire resistance</effect>
         </result>
         <ingredient amount="2">skull item:3</ingredient>

--- a/dtcm/standard/coreo/map.xml
+++ b/dtcm/standard/coreo/map.xml
@@ -12,12 +12,12 @@
 </contributors>
 <gamemode>dtc</gamemode>
 <broadcasts>
-    <tip after="5s">`e`l[Tip] `fGet `loreos `ffrom kill reward.</tip>
-    <tip after="10s">`e`l[Tip] `fBy using `ltwo (2) oreos `fyou can craft a `6Haste III`f potion!</tip>
-    <tip after="50s">`e`l[!] `fRemember to share oreos with your teammates!</tip>
-    <tip after="300s">`e`l[!] `fOreos.. hmm yummy!</tip>
-    <tip after="2m" every="2m">`e`l[Tip] `fGet `loreos `ffrom killrewards.</tip>
-    <tip after="2m" every="2m">`e`l[Tip] `fCraft a `6Haste III`f potion by using `ltwo (2) oreos`f.</tip>
+    <tip after="5s">`fGet `loreos `r`ffrom killing players.</tip>
+    <tip after="10s">`fBy using `l2 oreos `r`fyou can craft a `6Haste III`f potion!</tip>
+    <tip after="50s">`fRemember to share oreos with your teammates!</tip>
+    <tip after="300s">`fOreos.. mmm yummy!</tip>
+    <tip after="2m" every="2m">`fGet `loreos `r`ffrom killing players.</tip>
+    <tip after="2m" every="2m">`fCraft a `6Haste III`f potion by using `l2 oreos.</tip>
 </broadcasts>
 <teams>
     <team id="cookie-team" color="dark gray" max="12">Cookies</team>


### PR DESCRIPTION
- broadcast with tips about custom craft has been added.
- added night vision to the starter kits. cookie's team now doesn't have the dark clay's advantage.
- kill rewards give saturation. now cookies won't be a problem.