### PR TITLE
La Piazza - Remove apple game name

### DIFF
--- a/ffa/standard/la_piazza/map.xml
+++ b/ffa/standard/la_piazza/map.xml
@@ -1,9 +1,8 @@
 <map proto="1.4.0">
-<name>La Piazza Apple Game</name>
+<name>La Piazza</name>
 <version>1.0.7</version>
 <gamemode>ffa</gamemode>
 <objective>Get the most kills possible!</objective>
-<phase>development</phase>
 <authors>
     <author uuid="1aad55f7-2dea-4f22-85ca-ad9de3a78609" contribution="Map author and creator"/> <!-- Technodono -->
 </authors>


### PR DESCRIPTION
- Since the apple games is over the map's name has been reverted

- Since apple games are now over dev-phase has been removed... this will probabily also be this map's final version