### PR TITLE
Add creation date to most of my maps that are missing it.

### DIFF
--- a/blitz/standard/gold_in_them_thar_kills/map.xml
+++ b/blitz/standard/gold_in_them_thar_kills/map.xml
@@ -4,6 +4,7 @@
 <objective>Destroy the enemy team's monuments and then eliminate them!</objective>
 <gamemode>dtm</gamemode>
 <gamemode>blitz</gamemode>
+<created>2022-01-15</created>
 <time>20m</time>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4" contribution="Map building, theming, concept, XML, etc"/> <!-- Cazadorian -->

--- a/ctw/standard/quadrosphere_ctw/map.xml
+++ b/ctw/standard/quadrosphere_ctw/map.xml
@@ -3,6 +3,7 @@
 <version>1.2</version>
 <objective>Collect dyes from each spawner, get string from kills and craft them together to make the wools for your victory monuments!</objective>
 <gamemode>ctw</gamemode>
+<created>2021-12-25</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->
 </authors>

--- a/ctw/standard/stratosphere_ctw/map.xml
+++ b/ctw/standard/stratosphere_ctw/map.xml
@@ -4,6 +4,7 @@
 <version>1.2</version>
 <objective>Collect dyes from each spawner, get string from kills and craft them together to make the wools for your victory monuments!</objective>
 <gamemode>ctw</gamemode>
+<created>2021-10-31</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/>
     <!-- Cazadorian -->

--- a/dtcm/standard/mushroom_monuments/map.xml
+++ b/dtcm/standard/mushroom_monuments/map.xml
@@ -3,6 +3,7 @@
 <version>1.1.1</version>
 <objective>Destroy the enemy team's monument!</objective>
 <gamemode>dtm</gamemode>
+<created>2022-01-07</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->
 </authors>

--- a/flag/standard/thunderrush/map.xml
+++ b/flag/standard/thunderrush/map.xml
@@ -4,6 +4,7 @@
 <objective>Capture the most flags in 12m or gain a 3 point lead to win!</objective>
 <time result="score" overtime="1m" max-overtime="2m">12m</time>
 <gamemode>ctf</gamemode>
+<created>2022-12-27</created>
 <authors>
     <author uuid="fe3608b7-d105-4029-8800-34b3147065b6"/> <!-- rockymine -->
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->

--- a/flag/standard/thunderrush/map.xml
+++ b/flag/standard/thunderrush/map.xml
@@ -4,7 +4,7 @@
 <objective>Capture the most flags in 12m or gain a 3 point lead to win!</objective>
 <time result="score" overtime="1m" max-overtime="2m">12m</time>
 <gamemode>ctf</gamemode>
-<created>2022-12-27</created>
+<created>2021-12-27</created>
 <authors>
     <author uuid="fe3608b7-d105-4029-8800-34b3147065b6"/> <!-- rockymine -->
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->

--- a/mixed/standard/malupa/map.xml
+++ b/mixed/standard/malupa/map.xml
@@ -3,7 +3,7 @@
 <version>1.2.1</version>
 <objective>Capture the enemy team's two wools!</objective>
 <gamemode>ctw</gamemode>
-<created>2022-08-29</created>
+<created>2021-08-29</created>
 <authors>
     <author uuid="97d1cc45-0f69-482b-9974-09351aef9dfa"/> <!-- lunaceee -->
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->

--- a/mixed/standard/malupa/map.xml
+++ b/mixed/standard/malupa/map.xml
@@ -3,6 +3,7 @@
 <version>1.2.1</version>
 <objective>Capture the enemy team's two wools!</objective>
 <gamemode>ctw</gamemode>
+<created>2022-08-29</created>
 <authors>
     <author uuid="97d1cc45-0f69-482b-9974-09351aef9dfa"/> <!-- lunaceee -->
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->

--- a/scorebox/halloween/die_noon/map.xml
+++ b/scorebox/halloween/die_noon/map.xml
@@ -3,7 +3,7 @@
 <!-- Halloween version of "Miner Sixty Niner" -->
 <version>1.0.1</version>
 <objective>Kill enemies for nether quartz, drop into the chute with them for points!</objective>
-<created>2022-09-23</created>
+<created>2021-09-23</created>
 <gamemode>scorebox</gamemode>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- dragonstomper64 -->

--- a/scorebox/halloween/die_noon/map.xml
+++ b/scorebox/halloween/die_noon/map.xml
@@ -3,6 +3,7 @@
 <!-- Halloween version of "Miner Sixty Niner" -->
 <version>1.0.1</version>
 <objective>Kill enemies for nether quartz, drop into the chute with them for points!</objective>
+<created>2022-09-23</created>
 <gamemode>scorebox</gamemode>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- dragonstomper64 -->

--- a/scorebox/standard/bob-omb_battlefield/map.xml
+++ b/scorebox/standard/bob-omb_battlefield/map.xml
@@ -3,6 +3,7 @@
 <version>1.2.1</version>
 <objective>Kill enemies for stars, drop into the pipe with them for points!</objective>
 <gamemode>scorebox</gamemode>
+<created>2021-11-16</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian/dragonstomper64 -->
 </authors>

--- a/scorebox/standard/death_denile/map.xml
+++ b/scorebox/standard/death_denile/map.xml
@@ -3,6 +3,7 @@
 <version>1.1</version>
 <objective>Kill enemies for emeralds, drop into the chute with them for points!</objective>
 <gamemode>scorebox</gamemode>
+<created>2021-10-02</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian/dragonstomper64 -->
 </authors>
@@ -344,4 +345,3 @@
     <timeset>6000</timeset>
 </world>
 </map>
- 

--- a/scorebox/standard/miner_sixty_niner/map.xml
+++ b/scorebox/standard/miner_sixty_niner/map.xml
@@ -3,6 +3,7 @@
 <version>1.2</version>
 <objective>Kill enemies for gold nuggets, drop into the chute with them for points!</objective>
 <gamemode>scorebox</gamemode>
+<created>2020-10-16</created>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- dragonstomper64 -->
     <author uuid="bf331953-4f92-43ee-8abc-7544b8234936" contribution="Map building, theming, misc"/> <!-- Vicei in Minecraft, aka Vice -->

--- a/tdm/standard/quadrosphere_rage/map.xml
+++ b/tdm/standard/quadrosphere_rage/map.xml
@@ -4,6 +4,7 @@
 <objective>Be the team with the most points after 8 minutes!</objective>
 <gamemode>koth</gamemode>
 <gamemode>rage</gamemode>
+<created>2022-01-25</created>
 <time>8m</time>
 <authors>
     <author uuid="6863869b-4b8c-4445-b778-a8e016775ae4"/> <!-- Cazadorian -->


### PR DESCRIPTION
Creation dates added to a bunch of my maps via <created>, the last few maps that still lack the tag either aren't intended to ever play again at any stage or will have it included with future planned map updates.

Date added to:
- Bob-Omb Battlefield
- Death DeNile
- Die Noon
- Gold in Them Thar Kills
- Malupa
- Miner Sixty Niner
- Mushroom Monuments
- Quadrosphere CTW
- Quadrosphere Rage
- Stratosphere CTW
- Thunderrush
