### PR TITLE
Transit: v1.1.5

### DIFF
--- a/ad/tdm/Transit/map.xml
+++ b/ad/tdm/Transit/map.xml
@@ -1,31 +1,28 @@
 <map proto="1.4.2">
 <name>Transit</name>
-<version>1.1.4</version>
+<version>1.1.5</version>
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <created>2022-07-27</created>
 <gamemode>Rage</gamemode>
 <gamemode>AD</gamemode>
 <time>5m</time>
 <score>
-    <box points="8" filter="only-bombers" region="bomber-scoreboxes"/>
-    <kills>2</kills>
+    <box points="5" filter="only-bombers" region="bomber-scoreboxes"/>
+    <kills>1</kills>
     <deaths>0</deaths>
 </score>
 <authors>
     <author uuid="5876ff18-006d-4a1d-83d8-53abd8002578"/> <!-- LKFJimmy -->
     <author uuid="f2efb814-9e02-4d17-bdf5-8ed449f9df77"/> <!-- Alexander_ -->
 </authors>
-<rules>
-    <rule>Fall damage is disabled!</rule>
-</rules>
 <broadcasts>
-    <tip after="1s" every="30s">Use Cobweb to block Bombers from scoring!</tip>
-    <tip after="3s" every="30s">Use TNT to break the Cobweb from Guards and Reach to the Scorebox!</tip>
-    <tip after="5s" every="45s">Don't fall onto the rail!</tip>
-    <tip after="7s" every="30s">The scorebox is located in the last compartment!</tip>
-    <tip after="9s" every="45s">Stained glass panes are breakable and renewable!</tip>
-    <tip after="11s" every="45s">Guards can gain speed from kill!</tip>
-    <tip after="13s" every="1m">Two jump boost effects are hidden somewhere near the bombers' spawn. Use them strategically!</tip>
+    <alert after="1s" every="30s">Don't fall onto the rail!</alert>
+    <tip after="2s" every="40s">The scorebox is located in the last compartment!</tip>
+    <tip after="15s" every="30s" filter="only-guards">Use Cobweb to block Bombers from scoring!</tip>
+    <tip after="15s" every="30s" filter="only-bombers">Use TNT to break the Cobweb from Guards and Reach to the Scorebox!</tip>
+    <tip after="30s" every="50s">Stained glass panes are breakable and renewable!</tip>
+    <tip after="45s" every="55s" filter="only-guards">Guards can gain speed from kill!</tip>
+    <tip after="1m" every="1m" filter="only-bombers">Two jump boost effects are hidden somewhere near the bombers' spawn. Use them strategically!</tip>
 </broadcasts>
 <teams>
     <team id="bombers" color="red" max="8" max-overfill="10">Bombers</team>
@@ -41,11 +38,11 @@
         <effect duration="3" amplifier="25">damage resistance</effect>
     </kit>
     <kit id="bomber-kit" parents="spawn">
-	<effect amplifier="3">speed</effect>
+	<effect amplifier="2">speed</effect>
         <chestplate color="FF0C0C" unbreakable="true">leather chestplate</chestplate>
         <leggings color="FF0C0C" unbreakable="true">leather leggings</leggings>
         <boots color="FF0C0C" unbreakable="true">leather boots</boots>
-        <item slot="1" amount="3" name="`cBomb `6| `bFuse: 0.7s `6| `bPower: 2" lore="`9Use this strategically! It could be helpful...">tnt</item>
+        <item slot="1" amount="3" name="`cBomb `6| `bFuse: 1s `6| `bPower: 2" lore="`9Use this strategically! It could be helpful...">tnt</item>
     </kit>
     <kit id="guard-kit" parents="spawn">
 	<effect amplifier="1">speed</effect>
@@ -94,7 +91,7 @@
     <instantignite>on</instantignite>
     <licensing>off</licensing>
     <friendly-defuse>off</friendly-defuse>
-    <fuse>0.7s</fuse>
+    <fuse>1s</fuse>
     <power>2</power>
     <blockdamage>true</blockdamage>
 </tnt>
@@ -137,13 +134,10 @@
 </regions>
 <portals>
     <!-- portals from score zones to bases -->
-    <portal observers="never" x="@-19.5" y="@32" z="@0.5" yaw="@-90" filter="only-bombers">
-        <region id="bomber-scoreboxes"/>
-    </portal>
-    <portal filter="only-bombers" yaw="@-90" region="bomber-scoreboxes" destination="bomber-spawn"/>
+    <portal observers="never" filter="only-bombers" yaw="@-90" region="bomber-scoreboxes" destination="bomber-spawn"/>
 </portals>
 <renewables>
-    <renewable rate="1" particles="true" sound="false" avoid-players="5">
+    <renewable interval="3s" particles="true" sound="false" avoid-players="5">
         <region><cuboid min="-oo,18,-oo" max="oo,21,oo"/></region>
         <renew-filter><any><material damage="8">stained_glass_pane</material></any></renew-filter>
     </renewable>
@@ -171,13 +165,11 @@
     <item>pumpkin pie</item>
 </itemremove>
 <toolrepair>
-    <tool>iron sword</tool>
-    <tool>bow</tool>
     <tool>arrow</tool>
 </toolrepair>
 <kill-rewards>
     <kill-reward filter="only-bombers">
-        <item amount="2" name="`cBomb `6| `bFuse: 0.7s `6| `bPower: 2" lore="`9Use this strategically! It could be helpful...">tnt</item>
+        <item amount="2" name="`cBomb `6| `bFuse: 1s `6| `bPower: 2" lore="`9Use this strategically! It could be helpful...">tnt</item>
     </kill-reward>
     <kill-reward filter="only-guards">
         <item amount="2" lore="`9Use this strategically! It could be helpful...">web</item>


### PR DESCRIPTION
- nerf bomber (slower tnt fuse and reduce speed effect)
- adjust score to half (5 points from scorebox, 1 point from kill)
- fix portal to not teleport observer
- adjust renew rate of stained glass pane
- improve tips and alert
- remove unnecessary lines