### PR TITLE
Rename flag runners game mode to flag assault

### DIFF
--- a/flag/standard/royal_rumble_II/map.xml
+++ b/flag/standard/royal_rumble_II/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0">
 <name>Royal Rumble II</name>
-<version>2.0.4</version>
+<version>2.0.5</version>
 <objective>Score your flag in the enemy hoops, Most points wins!</objective>
 <created>2022-02-13</created>
 <authors>
@@ -10,7 +10,7 @@
     <rule>Fall damage is disabled!</rule>
 </rules>
 <gamemode>ctf</gamemode>
-<game>Flag Runners</game>
+<game>Flag Assault</game>
 <!--  Tips -->
 <broadcasts>
     <tip after="1s" every="2m">Remeber to defend your teams rings from the enemy flag carrier!</tip>

--- a/flag/standard/the_big_dig/map.xml
+++ b/flag/standard/the_big_dig/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>The Big Dig</name>
-<version>1.0.5</version>
+<version>1.0.6</version>
 <objective>Score your flag in the enemy goals, Most points wins!</objective>
 <created>2022-05-06</created>
 <time overtime="1s" max-overtime="2m">8m</time>
@@ -11,7 +11,7 @@
     <rule>Fall damage is disabled!</rule>
 </rules>
 <gamemode>ctf</gamemode>
-<game>Flag Runners</game>
+<game>Flag Assault</game>
 <!-- Tips -->
 <broadcasts>
     <tip after="1s" every="2m">Remeber to defend your teams goals from the enemy flag carrier!</tip>


### PR DESCRIPTION
From feedback based on mapdev's and my own informed opinion I figured that the name flag runners wasn't too intuitive and did not give the user much of an idea of the game mode being played. I switched it to assault cause it plays similarly to an old halo gamed (thanks halo)