### PR TITLE
Deadly Gaze: Fix region boundaries

### DIFF
--- a/dtcm/standard/deadly_gaze/map.xml
+++ b/dtcm/standard/deadly_gaze/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Deadly Gaze</name>
-<version>1.0</version>
+<version>1.0.1</version>
 <phase>development</phase>
 <objective>Destroy the enemy's monuments above their spawn!</objective>
 <created>2022-11-11</created>
@@ -111,13 +111,13 @@
     </union>
     <apply block="deny-skull" region="skull-areas" message="You may not break nor place that block here!"/>
     <union id="blocked-areas">
-        <cuboid min="-16,15,-97" max="-15,60,-70"/> <!-- blue side -->
-        <cuboid min="-9,15,-172" max="-10,60,-200"/> <!-- red side -->
+        <cuboid min="-16,16,-97" max="-15,60,-70"/> <!-- blue side -->
+        <cuboid min="-9,16,-172" max="-10,60,-200"/> <!-- red side -->
     </union>
     <apply enter="never" region="blocked-areas" message="You may not go through here!"/>
     <union id="spawn-areas">
-        <cuboid id="blue-spawn-area" min="-10,0,-87" max="-21,19,-80"/>
-        <cuboid id="red-spawn-area" min="-15,0,-182" max="-4,19,-189"/>
+        <cuboid id="blue-spawn-area" min="-11,0,-88" max="-21,19,-80"/>
+        <cuboid id="red-spawn-area" min="-14,0,-181" max="-5,19,-189"/>
     </union>
     <apply block="never" region="spawn-areas" message="You may not modify spawn areas!"/>
     <apply enter="only-blue" region="blue-spawn-area" message="You may not enter your enemy's spawn!"/>


### PR DESCRIPTION
**XML (regions):**
- Fix spawn area boundaries (as players were able to break the carpet and piston blocks due to layout changes)
- Raise no entry area above spawn by 1 block

Found during local testing