### PR TITLE
Deadly Gaze: Switch to using blocks filter

### DIFF
--- a/dtcm/standard/deadly_gaze/map.xml
+++ b/dtcm/standard/deadly_gaze/map.xml
@@ -91,6 +91,9 @@
                     <material>double plant</material>
                     <material>barrier</material>
                     <material>bedrock</material>
+                    <material>cobblestone</material>
+                    <material>mossy cobblestone</material>
+                    <material>step:3</material>
                 </any>
             </not>
         </blocks>

--- a/dtcm/standard/deadly_gaze/map.xml
+++ b/dtcm/standard/deadly_gaze/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Deadly Gaze</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <phase>development</phase>
 <objective>Destroy the enemy's monuments above their spawn!</objective>
 <created>2022-11-11</created>
@@ -68,25 +68,32 @@
     <deny id="deny-blue">
         <team id="only-blue">blue-team</team>
     </deny>
-    <deny id="deny-skull">
-        <any>
-            <material>sandstone</material>
-            <material>smooth brick</material>
-            <material>smooth stairs</material>
-            <material>step:5</material>
-            <material>ender stone</material>
-            <material>double step:5</material>
-            <material>wood:2</material>
-            <material>web</material>
-            <material>coal block</material>
-            <material>ladder</material>
-            <material>sea lantern</material>
-            <material>flower pot</material>
-            <material>sandstone stairs</material>
-            <material>step:1</material>
-            <material>double step:1</material>
-            <material>birch wood stairs</material>
-        </any>
+    <deny id="skull-protection">
+        <blocks region="skull-areas">
+            <not>
+                <any>
+                    <material>air</material>
+                    <material>stone</material>
+                    <material>dirt</material>
+                    <material>leaves</material>
+                    <material>dark oak fence</material>
+                    <material>redstone torch on</material>
+                    <material>long grass</material>
+                    <material>brown mushroom</material>
+                    <material>red rose</material>
+                    <material>vine</material>
+                    <material>wood step:1</material>
+                    <material>wood:1</material>
+                    <material>gold block</material>
+                    <material>wood button</material>
+                    <material>gravel</material>
+                    <material>grass</material>
+                    <material>double plant</material>
+                    <material>barrier</material>
+                    <material>bedrock</material>
+                </any>
+            </not>
+        </blocks>
     </deny>
     <deny id="deny-web">
         <material>web</material>
@@ -106,10 +113,16 @@
     </negative>
     <apply block-break="deny-web" region="middle-tree" message="You may not break the cobwebs!"/>
     <union id="skull-areas">
-        <above z="-97"/> <!-- blue side -->
-        <below z="-172"/> <!-- red side -->
+        <complement>
+            <cuboid min="-36,0,-97" max="5,55,-77"/> <!-- blue side -->
+            <region id="blue-spawn-area"/>
+        </complement>
+        <complement>
+            <cuboid min="11,0,-172" max="-30,55,-192"/> <!-- red side -->
+            <region id="red-spawn-area"/>
+        </complement>
     </union>
-    <apply block="deny-skull" region="skull-areas" message="You may not break nor place that block here!"/>
+    <apply block="skull-protection" region="skull-areas" message="You may not modify the original skull!"/>
     <union id="blocked-areas">
         <cuboid min="-16,16,-97" max="-15,60,-70"/> <!-- blue side -->
         <cuboid min="-9,16,-172" max="-10,60,-200"/> <!-- red side -->


### PR DESCRIPTION
Makes the skull regions bounded so that they work with the filter as well.

Mostly just so it has better support for weird blocks like some upper halves of slabs that were breakable before