### PR TITLE
Fix incorrect text box for map update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/map-update.yaml
+++ b/.github/ISSUE_TEMPLATE/map-update.yaml
@@ -38,7 +38,7 @@ body:
         and link it here.
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: map-download
     attributes:
       label: Download Link


### PR DESCRIPTION
Changes the textbox into a different one where it'll let users drag a .zip file to upload

Previously, it was using the smaller box below while other templates were using the larger textarea input.
![image](https://user-images.githubusercontent.com/20259871/205471094-4538336b-98b3-43cb-a4e6-729c4c2b27c4.png)
