### PR TITLE
Armature: Fix block drop chances and lower obs spawns

### DIFF
--- a/dtcm/standard/armature/map.xml
+++ b/dtcm/standard/armature/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Armature</name>
-<version>1.0</version>
+<version>1.0.1</version>
 <objective>Destroy the enemy's monument and repair yours!</objective>
 <created>2022-11-19</created>
 <authors>
@@ -174,7 +174,7 @@
             </any>
         </filter>
         <drops>
-            <item chance="100" material="cobblestone"/>
+            <item chance="1" material="cobblestone"/>
         </drops>
     </rule>
     <rule>
@@ -182,7 +182,7 @@
             <material damage="8">double_step</material>
         </filter>
         <drops>
-            <item chance="100" material="cobblestone"/>
+            <item chance="1" material="cobblestone"/>
         </drops>
     </rule>
     <rule>
@@ -190,7 +190,7 @@
             <material>leaves</material>
         </filter>
         <drops>
-            <item chance="10" material="apple"/>
+            <item chance="0.05" material="apple"/>
         </drops>
     </rule>
 </block-drops>

--- a/dtcm/standard/armature/map.xml
+++ b/dtcm/standard/armature/map.xml
@@ -29,8 +29,8 @@
     </spawn>
     <default>
         <regions>
-            <point yaw="180">0.5,32.5,32.5</point> <!-- South -->
-            <point yaw="0">0.5,32.5,-31.5</point> <!-- North -->
+            <point yaw="180">0.5,32,32.5</point> <!-- South -->
+            <point yaw="0">0.5,32,-31.5</point> <!-- North -->
         </regions>
     </default>
 </spawns>


### PR DESCRIPTION
Also reduces drop rates from 10% to 5% for apples
Found during local testing