### PR TITLE
Add map submission guidelines checkbox to forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/contest-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/contest-submission.yaml
@@ -22,6 +22,10 @@ body:
             mentioned in the
             [README](https://github.com/OvercastCommunity/CommunityMaps#readme).
           required: false
+        - label: >-
+            I have read and understood the 
+            [map submission guidelines](https://oc.tc/submissions).
+          required: false
         - label: I have created an XML file.
           required: false
         - label: I have created a map image.

--- a/.github/ISSUE_TEMPLATE/map-submission.yaml
+++ b/.github/ISSUE_TEMPLATE/map-submission.yaml
@@ -21,6 +21,10 @@ body:
             mentioned in the
             [README](https://github.com/OvercastCommunity/CommunityMaps#readme).
           required: false
+        - label: >-
+            I have read and understood the 
+            [map submission guidelines](https://oc.tc/submissions).
+          required: false
         - label: I have created an XML file.
           required: false
         - label: I have created a map image.


### PR DESCRIPTION
Add a checkbox with a link to the submission guidelines to the map submission form. 
