### PR TITLE
The King's Lava Lair 1.0.3

### DIFF
--- a/flag/standard/the_kings_lava_lair/map.xml
+++ b/flag/standard/the_kings_lava_lair/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
     <name>The King's Lava Lair</name>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <phase>development</phase>
     <objective>Score your flag in the enemy goals, Most points wins!</objective>
     <created>2023-01-29</created>
@@ -25,6 +25,7 @@
     </teams>
     <kits>
         <kit id="spawn">
+            <clear/>
             <item slot="0" unbreakable="true">stone sword</item>
             <item slot="1" unbreakable="true">bow</item>
             <item slot="2" amount="6" projectile="arrow" name="`rCrossbow" lore="`r`7Right-click to fire!" material="firework charge"/>
@@ -176,6 +177,9 @@
         <item>firework charge</item>
         <item>sapling</item>
     </itemremove>
+    <itemkeep>
+        <item>leaves</item>
+    </itemkeep>
     <hunger>
         <depletion>off</depletion>
     </hunger>
@@ -186,6 +190,7 @@
     <!-- Scogoal and Flag settings  -->
     <killreward>
         <item amount="4">arrow</item>
+        <item amount="8">leaves</item>
         <item amount="1">golden apple</item>
         <item amount="3" projectile="arrow" name="`rCrossbow" lore="`r`7Right-click to fire!" material="firework charge"/>
     </killreward>


### PR DESCRIPTION
- add leaves to itemkeep to prevent drop on death
- clear inventory to prevent leave duplication
- Leaves added back to kill reward so it's balanced towards spawner play/control & not farming 24 leaves off each player