### PR TITLE
Transit v1.2.3 + Happy Rainbow v2.0.1

### DIFF
--- a/flag/standard/happy_rainbow/map.xml
+++ b/flag/standard/happy_rainbow/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Happy Rainbow</name>
-<version>2.0</version>
+<version>2.0.1</version>
 <objective>Capture the most flags in 8m or gain a 3 point lead to win!</objective>
 <time result="score" overtime="1m" max-overtime="2m">8m</time>
 <created>2022-08-15</created>
@@ -257,4 +257,7 @@
 <hunger>
     <depletion>off</depletion>
 </hunger>
+<disabledamage>
+    <damage>fall</damage>
+</disabledamage>
 </map>

--- a/tdm/halloween/transit_halloween/map.xml
+++ b/tdm/halloween/transit_halloween/map.xml
@@ -1,13 +1,13 @@
 <map proto="1.4.2">
 <name>Transit: Halloween Edition</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <created>2022-10-12</created>
 <gamemode>rage</gamemode>
 <gamemode>ad</gamemode>
 <time>5m</time>
 <score>
-    <box points="3" filter="only-bombers" region="bomber-scoreboxes"/>
+    <box points="5" filter="only-bombers" region="bomber-scoreboxes"/>
     <box filter="only-guards" region="guard-redeem">
         <redeemables>
             <item points="1">ink sack</item>
@@ -71,7 +71,7 @@
         <boots color="0CFF0C" unbreakable="true">leather boots</boots>
         <item slot="1" enchantment="arrow damage:10" unbreakable="true" name="`cBow">bow</item>
         <item slot="2" amount="3" name="`6Cobweb" lore="`9Place near the scorebox!">web</item>
-        <item slot="8" amount="2">arrow</item>
+        <item slot="8" amount="1">arrow</item>
     </kit>
     <kit id="default">
        <effect duration="oo" amplifier="1">night vision</effect>
@@ -81,7 +81,7 @@
         <effect amplifier="255">wither</effect>
     </kit>
     <kit id="guard-kill-reward-arrow" force="true">
-        <item slot="8" amount="2">arrow</item>
+        <item slot="8" amount="1">arrow</item>
     </kit>
     <kit id="bomber-scorebox-reward" force="true">
         <item name="`6Smoke Bomb" projectile="smokebomb" grenade="true" grenade-power="1.6" material="snowball" lore="`9Ranged! Explosive!"/>

--- a/tdm/standard/transit/map.xml
+++ b/tdm/standard/transit/map.xml
@@ -1,13 +1,13 @@
 <map proto="1.4.2">
 <name>Transit</name>
-<version>1.2.2</version>
+<version>1.2.3</version>
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <created>2022-07-27</created>
 <gamemode>rage</gamemode>
 <gamemode>ad</gamemode>
 <time>5m</time>
 <score>
-    <box points="3" filter="only-bombers" region="bomber-scoreboxes"/>
+    <box points="5" filter="only-bombers" region="bomber-scoreboxes"/>
     <box filter="only-guards" region="guard-redeem">
         <redeemables>
             <item points="1">gold nugget</item>
@@ -71,7 +71,7 @@
         <boots color="FFCC0C" unbreakable="true">leather boots</boots>
         <item slot="1" enchantment="arrow damage:10" unbreakable="true" name="`cBow">bow</item>
         <item slot="2" amount="3" name="`6Cobweb" lore="`9Place near the scorebox!">web</item>
-        <item slot="8" amount="2">arrow</item>
+        <item slot="8" amount="1">arrow</item>
     </kit>
     <kit id="default">
        <effect duration="oo" amplifier="1">night vision</effect>
@@ -81,7 +81,7 @@
         <effect amplifier="255">wither</effect>
     </kit>
     <kit id="guard-kill-reward-arrow" force="true">
-        <item slot="8" amount="2">arrow</item>
+        <item slot="8" amount="1">arrow</item>
     </kit>
     <kit id="bomber-scorebox-reward" force="true">
         <item name="`6Smoke Bomb" projectile="smokebomb" grenade="true" grenade-power="1.6" material="snowball" lore="`9Ranged! Explosive!"/>


### PR DESCRIPTION
## Minor XML update
### Transit v1.2.3 and Transit: Halloween Edition v1.1.3
(sorry for updating it that frequent recently, cuz the redeemable led to many game balancing issues... Orz)
- reduce the amount of arrow in guards' kit & kill reward
- increase the scores of bombers' scorebox

### Happy Rainbow v2.0.1
-  remove fall damage