### PR TITLE
Transit: v1.2.5

### DIFF
--- a/tdm/halloween/transit_halloween/map.xml
+++ b/tdm/halloween/transit_halloween/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Transit: Halloween Edition</name>
-<version>1.1.4</version>
+<version>1.1.5</version>
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <created>2022-10-12</created>
 <gamemode>rage</gamemode>
@@ -8,11 +8,6 @@
 <time>5m</time>
 <score>
     <box points="3" filter="only-bombers" region="bomber-scoreboxes"/>
-    <box filter="only-guards" region="guard-redeem">
-        <redeemables>
-            <item points="1">ink sack</item>
-        </redeemables>
-    </box>
     <kills>1</kills>
     <deaths>0</deaths>
 </score>
@@ -159,7 +154,6 @@
         </union>
     </negative>
     <cuboid id="tracks" min="-oo,-oo,-oo" max="oo,15.5,oo"/>
-    <cuboid id="guard-redeem" min="-oo,19,-oo" max="oo,20,oo"/>
     <apply block="never" region="restricted" message="You may not edit this area!"/>
     <apply block="interactable" message="You may only break glass panes and cobwebs!"/>
     <apply kit="force-kill" region="tracks"/>
@@ -208,9 +202,6 @@
     <item>pumpkin pie</item>
     <item>snowball</item>
 </itemremove>
-<itemkeep>
-    <item>ink sack</item>
-</itemkeep>
 <toolrepair>
     <tool>arrow</tool>
 </toolrepair>
@@ -220,7 +211,6 @@
     </kill-reward>
     <kill-reward filter="only-guards">
         <item amount="2" name="`6Cobweb" lore="`9Place near the scorebox!">web</item>
-        <item name="`aCandy" damage="10" lore="`9Jump up to redeem one point!">ink sack</item>
     </kill-reward>
     <kill-reward>
         <filter>

--- a/tdm/standard/transit/map.xml
+++ b/tdm/standard/transit/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Transit</name>
-<version>1.2.4</version>
+<version>1.2.5</version>
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <created>2022-07-27</created>
 <gamemode>rage</gamemode>
@@ -8,11 +8,6 @@
 <time>5m</time>
 <score>
     <box points="3" filter="only-bombers" region="bomber-scoreboxes"/>
-    <box filter="only-guards" region="guard-redeem">
-        <redeemables>
-            <item points="1">gold nugget</item>
-        </redeemables>
-    </box>
     <kills>1</kills>
     <deaths>0</deaths>
 </score>
@@ -159,7 +154,6 @@
         </union>
     </negative>
     <cuboid id="tracks" min="-oo,-oo,-oo" max="oo,15.5,oo"/>
-    <cuboid id="guard-redeem" min="-oo,19,-oo" max="oo,20,oo"/>
     <apply block="never" region="restricted" message="You may not edit this area!"/>
     <apply block="interactable" message="You may only break glass panes and cobwebs!"/>
     <apply kit="force-kill" region="tracks"/>
@@ -207,7 +201,6 @@
     <item>carrot item</item>
     <item>pumpkin pie</item>
     <item>snowball</item>
-    <item>gold nugget</item>
 </itemremove>
 <toolrepair>
     <tool>arrow</tool>
@@ -218,7 +211,6 @@
     </kill-reward>
     <kill-reward filter="only-guards">
         <item amount="2" name="`6Cobweb" lore="`9Place near the scorebox!">web</item>
-        <item lore="`9Jump up to redeem one point!">gold nugget</item>
     </kill-reward>
     <kill-reward>
         <filter>


### PR DESCRIPTION
#### Remove redeemable
Redeemable has caused serious game balancing issue since its implementation in v1.2 
and its jump-up-to-score mechanism does not work well. 
It is initially designed to let guards to have an chance to score as bomber did 
and to reduce guards' confusion when they observe a scoring message from bombers. 
Turn out this is not a good solution after various adjustments, 
hopefully seek an alternative approach in later updates. Thanks!