### PR TITLE
Prisma CTW: Fix wr use filter

### DIFF
--- a/ctw/standard/prisma_ctw/map.xml
+++ b/ctw/standard/prisma_ctw/map.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.4.0">
 <name>Prisma CTW</name>
-<version>1.0.1</version>
-<phase>development</phase>
+<version>1.0.2</version>
 <objective>Get the enemy's wool to win!</objective>
 <authors>
     <author uuid="924c4e61-57b6-4931-afdb-6525b2ed34c0"/> <!-- OAF6 -->
@@ -87,8 +86,8 @@
         <rectangle id="blue-spawn" min="-8,-127" max="0,-113"/>
         <rectangle id="red-spawn" min="33,-48" max="41,-34"/>
     </union>
-    <apply region="pink-woolroom" enter="only-blue" block="only-blue-cobweb"/>
-    <apply region="magenta-woolroom" enter="only-red" block="only-red-cobweb"/>
+    <apply region="pink-woolroom" enter="only-blue" use="only-blue" block="only-blue-cobweb"/>
+    <apply region="magenta-woolroom" enter="only-red" use="only-red" block="only-red-cobweb"/>
     <apply region="blue-spawn" enter="only-blue" message="You may not enter the enemy team's spawn area!"/>
     <apply region="red-spawn" enter="only-red" message="You may not enter the enemy team's spawn area!"/>
     <apply region="spawn-areas" block="never" message="You may not modify spawn!"/>


### PR DESCRIPTION
Players were able to open their own wool room chests by breaking the glass and quickly right clicking the chest, this fixes it. Also remove dev phase since map was added to pool.