### PR TITLE
Update Boar Beach to version 1.3.1

### DIFF
--- a/flag/standard/boar_beach/map.xml
+++ b/flag/standard/boar_beach/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Boar Beach</name>
-<version>1.3.0</version>
+<version>1.3.1</version>
 <objective>Get the most points in 7 minutes!</objective>
 <created>2023-01-26</created>
 <authors>
@@ -170,29 +170,31 @@
         <flag-returned post="blue-post-emerald-flag">emerald-flag</flag-returned>
         <flag-returned post="red-post-emerald-flag">emerald-flag</flag-returned>
     </any>
-    <all id="send-flag-unreleased-alert">
-        <participating/>
-        <any>
-            <all>
-                <region id="diamond-flag-alert"/>
-                <not>
-                    <filter id="trigger-diamond-release"/>
-                </not>
-            </all>
-            <all>
-                <region id="gold-flag-alert"/>
-                <not>
-                    <filter id="trigger-gold-release"/>
-                </not>
-            </all>
-            <all>
-                <region id="emerald-flag-alert"/>
-                <not>
-                    <filter id="trigger-emerald-release"/>
-                </not>
-            </all>
-        </any>
-    </all>
+    <pulse id="send-flag-unreleased-alert" period="1s" duration="0.5">
+        <all>
+            <participating/>
+            <any>
+                <all>
+                    <region id="diamond-flag-alert"/>
+                    <not>
+                        <filter id="trigger-diamond-release"/>
+                    </not>
+                </all>
+                <all>
+                    <region id="gold-flag-alert"/>
+                    <not>
+                        <filter id="trigger-gold-release"/>
+                    </not>
+                </all>
+                <all>
+                    <region id="emerald-flag-alert"/>
+                    <not>
+                        <filter id="trigger-emerald-release"/>
+                    </not>
+                </all>
+            </any>
+        </all>
+    </pulse>
     <any id="block-whitelist">
         <material>tnt</material>
         <material>long grass</material>
@@ -249,9 +251,9 @@
 <flags shared="true" carry-message="Return the flag to your team's skull!" deny-message="Return the flag to your team's skull!">
     <flag id="blue-flag"    name="Blue Flag"    color="blue"   shared="true" post="blue-post-blue-flag"/>
     <flag id="red-flag"     name="Red Flag"     color="red"    shared="true" post="red-post-red-flag"/>
-    <flag id="diamond-flag" name="Diamond Flag" color="cyan"   shared="true" post="diamond-init-post"/>
-    <flag id="gold-flag"    name="Gold Flag"    color="yellow" shared="true" post="gold-init-post"/>
-    <flag id="emerald-flag" name="Emerald Flag" color="lime"   shared="true" post="emerald-init-post"/>
+    <flag id="diamond-flag" name="Diamond Flag" color="cyan"   shared="true" post="diamond-init-post" scoreboard-filter="trigger-diamond-release"/>
+    <flag id="gold-flag"    name="Gold Flag"    color="yellow" shared="true" post="gold-init-post"    scoreboard-filter="trigger-gold-release"/>
+    <flag id="emerald-flag" name="Emerald Flag" color="lime"   shared="true" post="emerald-init-post" scoreboard-filter="trigger-emerald-release"/>
     <post id="diamond-init-post" recover-time="3s" yaw="90">13,9,0</post>
     <post id="gold-init-post"    recover-time="3s" yaw="90">0,7,0</post>
     <post id="emerald-init-post" recover-time="3s" yaw="-90">-13,9,0</post>


### PR DESCRIPTION
- Use `scoreboard-filter` property to hide flags not in play from objectives scoreboard
- Use `<pulse>...</pulse>` filter to persist message triggers while player remains in required regions