### PR TITLE
Curly Pride: add stone axe to toolrepair

### DIFF
--- a/ctw/standard/curly_pride/map.xml
+++ b/ctw/standard/curly_pride/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Curly Pride</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
 <objective>Capture the enemy team's wool!</objective>
 <created>2022-08-28</created>
 <authors>
@@ -124,6 +124,7 @@
     <tool>bow</tool>
     <tool>arrow</tool>
     <tool>iron pickaxe</tool>
+    <tool>stone axe</tool>
     <tool>iron spade</tool>
 </toolrepair>
 <itemremove>


### PR DESCRIPTION
To prevent filling up player inventories