### PR TITLE
Greenhill: Update wood on killreward

### DIFF
--- a/ctw/standard/greenhill/map.xml
+++ b/ctw/standard/greenhill/map.xml
@@ -169,7 +169,7 @@
 <kill-rewards>
     <kill-reward>
         <item>golden apple</item>
-        <item amount="16">wood</item>
+        <item amount="16" damage="2">wood</item>
         <item amount="8">glass</item>
     </kill-reward>
 </kill-rewards>


### PR DESCRIPTION
Make the wood in the kill reward the same type of wood as the spawn kit so it can stack