### PR TITLE
Amusement Park + Halloween Ed.: deny more doors

### DIFF
--- a/arcade/infection/infection_amusement_park/map.xml
+++ b/arcade/infection/infection_amusement_park/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0" game="Infection">
 <name>Infection: Amusement Park</name>
-<version>1.0.8</version>
+<version>1.0.9</version>
 <objective>Kill all the humans before the 8 minutes are up!</objective>
 <created>2022-04-01</created>
 <gamemode>arcade</gamemode>
@@ -99,6 +99,16 @@
     <union id="door-region">
         <block>48,10,-119</block>
         <block>48,11,-119</block>
+        <block>47,10,-132</block>
+        <block>47,11,-132</block>
+        <block>51,9,-136</block>
+        <block>51,10,-136</block>
+        <block>45,11,-127</block>
+        <block>45,12,-127</block>
+        <block>26,6,-87</block>
+        <block>26,7,-87</block>
+        <block>27,3,-86</block>
+        <block>27,4,-86</block>
     </union>
     <!-- applicators -->
     <apply use="deny-door" region="door-region"/>

--- a/arcade/infection/infection_amusement_park_halloween_edition/map.xml
+++ b/arcade/infection/infection_amusement_park_halloween_edition/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.0" game="Infection">
 <name>Infection: Amusement Park Halloween Edition</name>
-<version>1.0.2</version> <!-- Regular 1.0.8 -->
+<version>1.0.3</version> <!-- Regular 1.0.9 -->
 <phase>development</phase>
 <objective>Kill all the humans before the 8 minutes are up!</objective>
 <created>2022-10-03</created>
@@ -100,6 +100,16 @@
     <union id="door-region">
         <block>48,10,-119</block>
         <block>48,11,-119</block>
+        <block>47,10,-132</block>
+        <block>47,11,-132</block>
+        <block>51,9,-136</block>
+        <block>51,10,-136</block>
+        <block>45,11,-127</block>
+        <block>45,12,-127</block>
+        <block>26,6,-87</block>
+        <block>26,7,-87</block>
+        <block>27,3,-86</block>
+        <block>27,4,-86</block>
     </union>
     <!-- applicators -->
     <apply use="deny-door" region="door-region"/>


### PR DESCRIPTION
Change requested by the map author: deny usage of some more doors that hiders could close, but seekers were not able to open it again because of the paintings in front of it