### PR TITLE
Crater Resort: disable TNT damage for allies

### DIFF
--- a/flag/standard/crater_resort/map.xml
+++ b/flag/standard/crater_resort/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Crater Resort</name>
-<version>1.0.2</version>
+<version>1.0.3</version>
 <objective>Hold the flag for 150 seconds to win!</objective>
 <gamemode>kotf</gamemode>
 <authors>
@@ -193,6 +193,7 @@
 </kill-rewards>
 <disabledamage>
     <damage>fall</damage>
+    <damage self="false" enemy="false">block explosion</damage>
 </disabledamage>
 <hunger>
     <depletion>off</depletion>


### PR DESCRIPTION
- TNT damages enemies and self, but not teammates