### PR TITLE
Colorado & Gloomwald: Also apply new height limits to wool room regions

### DIFF
--- a/ctw/standard/colorado/map.xml
+++ b/ctw/standard/colorado/map.xml
@@ -1,8 +1,9 @@
 <map proto="1.4.2">
 <name>Colorado</name>
-<version>1.1.2</version>
+<version>1.1.3</version>
 <objective>Capture the two wools of the enemy team!</objective>
 <created>2022-10-08</created>
+<constant id="height-limit">29</constant>
 <authors>
     <author uuid="e4cfa2d5-6b11-4e15-a893-9d92f18385f3"/> <!-- mariogoat -->
     <author uuid="660a9502-4872-43ba-b7f7-1f49ab588526"/> <!-- FbprZ7 -->
@@ -46,7 +47,7 @@
     </default>
     <spawn team="red-team" kit="spawn-kit">
         <region yaw="-90">
-            <point>-218,12,9.5</point>
+            <point>-218.5,12,9.5</point>
         </region>
     </spawn>
     <spawn team="blue-team" kit="spawn-kit">
@@ -100,12 +101,12 @@
     </union>
     <union id="wool-rooms-blocks">
         <union id="red-wool-rooms-blocks">
-            <cuboid id="purple-wool-room-blocks" min="-197,0,33" max="-214,22,48"/>
-            <cuboid id="magenta-wool-room-blocks" min="-158,0,-39" max="-173,22,-56"/>
+            <cuboid id="purple-wool-room-blocks" min="-197,0,33" max="-214,${height-limit},48"/>
+            <cuboid id="magenta-wool-room-blocks" min="-158,0,-39" max="-173,${height-limit},-56"/>
         </union>
         <union id="blue-wool-rooms-blocks">
-            <cuboid id="lime-wool-room-blocks" min="9,0,-14" max="26,22,-29"/>
-            <cuboid id="green-wool-room-blocks" min="-30,0,58" max="-15,22,75"/>
+            <cuboid id="lime-wool-room-blocks" min="9,0,-14" max="26,${height-limit},-29"/>
+            <cuboid id="green-wool-room-blocks" min="-30,0,58" max="-15,${height-limit},75"/>
         </union>
     </union>
     <union id="water-area">
@@ -140,7 +141,7 @@
     <apply block="only-blue-wr-blocks" region="red-wool-rooms-blocks" message="You may not modify the wool rooms!"/>
     <apply block="never" region="wool-rooms" message="You may not modify the wool rooms!"/>
     <apply block-break="only-iron" block-place="only-iron-renew" region="spawns" message="You may only break iron blocks in the spawns!"/>
-    <apply block="only-water" region="water-area" message="You may only use water here!"/>
+    <!-- apply block="only-water" region="water-area" message="You may only use water here!"/ -->
     <apply block="deny-void" region="void-area" message="You may not modify the void area!"/>
 </regions>
 <wools craftable="false">
@@ -240,7 +241,7 @@
         <item amount="16" material="arrow"/>
     </kill-reward>
 </kill-rewards>
-<maxbuildheight>29</maxbuildheight>
+<maxbuildheight>${height-limit}</maxbuildheight>
 <hunger>
     <depletion>off</depletion>
 </hunger>

--- a/ctw/standard/gloomwald/map.xml
+++ b/ctw/standard/gloomwald/map.xml
@@ -1,8 +1,9 @@
 <map proto="1.4.2">
 <name>Gloomwald</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <objective>Capture the enemy team's two wools!</objective>
 <created>2023-05-27</created>
+<constant id="height-limit">23</constant>
 <authors>
     <author uuid="f8753ae6-a7ed-4d88-8d6d-537a5b1687e4"/> <!-- guini2 -->
     <author uuid="e4cfa2d5-6b11-4e15-a893-9d92f18385f3"/> <!-- mariogoat -->
@@ -109,12 +110,12 @@
     </union>
     <union id="wool-rooms-blocks">
         <union id="red-wool-rooms-blocks">
-            <cuboid id="red-wool-room-blocks" min="-36,0,35" max="-47,18,45"/>
-            <cuboid id="cyan-wool-room-blocks" min="-36,0,-38" max="-47,18,-28"/>
+            <cuboid id="red-wool-room-blocks" min="-36,0,35" max="-47,${height-limit},45"/>
+            <cuboid id="cyan-wool-room-blocks" min="-36,0,-38" max="-47,${height-limit},-28"/>
         </union>
         <union id="blue-wool-rooms-blocks">
-            <cuboid id="lime-wool-room-blocks" min="105,0,-28" max="116,18,-38"/>
-            <cuboid id="purple-wool-room-blocks" min="105,0,45" max="116,18,35"/>
+            <cuboid id="lime-wool-room-blocks" min="105,0,-28" max="116,${height-limit},-38"/>
+            <cuboid id="purple-wool-room-blocks" min="105,0,45" max="116,${height-limit},35"/>
         </union>
     </union>
     <negative id="void-area">
@@ -231,7 +232,7 @@
         <item amount="8" material="glass"/>
     </kill-reward>
 </kill-rewards>
-<maxbuildheight>23</maxbuildheight>
+<maxbuildheight>${height-limit}</maxbuildheight>
 <hunger>
     <depletion>off</depletion>
 </hunger>


### PR DESCRIPTION
Noticed the height limits on these maps got increased, this also applies the new limits to the wool room regions.

Also on Colorado fix red's spawn point and disable the rule that prevented players from placing blocks inside the water layers