### PR TITLE
Bed Wars: Thunderbird - 1.3.0 - Glass Fix

### DIFF
--- a/other/bedwars/thunderbird/map.xml
+++ b/other/bedwars/thunderbird/map.xml
@@ -37,7 +37,7 @@
 <!-- ======================================================================= -->
 <!-- |  Customize for your map: version, name, author, teams, regions, etc.  -->
 <!-- ======================================================================= -->
-<version>1.2.0</version>
+<version>1.3.0</version>
 <phase>development</phase>
 <name>Bed Wars: Thunderbird</name>
 <created>2023-08-10</created>
@@ -459,7 +459,7 @@
         <item material="wool" team-color="true" amount="16"/>
     </kit>
     <kit id="glass-store" deduct-items="false" drop-overflow="true">
-        <item material="glass" team-color="true" amount="4"/>
+        <item material="stained glass" team-color="true" amount="4"/>
     </kit>
     <kit id="obsidian-store" deduct-items="false" drop-overflow="true">
         <item material="obsidian" amount="4"/>
@@ -3263,7 +3263,7 @@
         <category id="blocks" name="`aBlocks" material="hard clay">
             <item material="wool" kit="wool-store" lore="`7Great for briding across islands." team-color="true" amount="16" price="4" currency="iron ingot" color="white"/>
             <item material="stained clay" team-color="true" amount="16" price="12" currency="iron ingot" color="white"/>
-            <item material="stained glass" kit="glass-store" team-color="true" name="`rBlastproof Glass" amount="4" price="12" currency="iron ingot" color="white"/>
+            <item material="stained glass" kit="glass-store" team-color="true" name="`rBlastproof Glass" lore="`bMore than one layer of glass|`bmay be required to prevent blast|`bdamage to blocks below.||`bYour bed is immune to TNT and Fireballs.||" amount="8" price="12" currency="iron ingot" color="white"/>
             <item material="ender stone" amount="12" price="24" currency="iron ingot" color="white"/>
             <item material="ladder" amount="8" price="4" currency="iron ingot" color="white"/>
             <item material="wood" kit="wood-store" name="`6Wood" amount="16" price="4" currency="gold ingot" color="yellow"/>


### PR DESCRIPTION
- Correct the material from glass to stained glass, which resolves glass getting destroyed
- Explain in store that glass probably needs more than 1 layer
- Discount the item by doubling the materials