### PR TITLE
BlockGlitch 4: v1.1.2

### DIFF
--- a/arcade/standard/blockglitch_4/map.xml
+++ b/arcade/standard/blockglitch_4/map.xml
@@ -2,7 +2,7 @@
 <!-- #region meta -->
 <name>BlockGlitch 4</name>
 <slug>blockglitch_4_hell_edition</slug>
-<!-- Commit ID: be9dd6ac464c4358640f7fa4903452abb4c19ae6 -->
+<!-- Commit ID: 5de932274acb2c665923736bc5bb47ee72d2675b -->
 <version>1.1.2</version>
 <created>2023-10-22</created>
 <objective>Be the first one to finish the parkour!</objective>
@@ -436,40 +436,40 @@
         <item slot="0" material="${LEVELLED_ITEM_9}" amount="64" prevent-sharing="true" />
     </kit>
 </kits>
-<portals>
+<portals yaw="@0" pitch="@0" observers="never" sound="false">
     <!--
         The portal system doesn't support teleporting to a set of points as it is
         coerced to an union, which is not randomize-able. Therefore, we're teleporting
         to a single point determined by a randomized variable, and then we move them
         by a predetermined offset up to the desired destination.
     -->
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=1)" x="58" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=2)" x="116" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=3)" x="174" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=4)" x="232" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=5)" x="290" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=6)" x="348" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=7)" x="406" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=8)" x="464" observers="never" sound="false" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=9)" x="522" observers="never" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-9, tp_checkpoint=..8)" yaw="@0" pitch="@0" observers="never" destination="cp-9" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=8..)" yaw="@0" pitch="@0" observers="never" destination="cp-9" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=..7)" yaw="@0" pitch="@0" observers="never" destination="cp-8" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=7..)" yaw="@0" pitch="@0" observers="never" destination="cp-8" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=..6)" yaw="@0" pitch="@0" observers="never" destination="cp-7" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=6..)" yaw="@0" pitch="@0" observers="never" destination="cp-7" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=..5)" yaw="@0" pitch="@0" observers="never" destination="cp-6" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=5..)" yaw="@0" pitch="@0" observers="never" destination="cp-6" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=..4)" yaw="@0" pitch="@0" observers="never" destination="cp-5" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=4..)" yaw="@0" pitch="@0" observers="never" destination="cp-5" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=..3)" yaw="@0" pitch="@0" observers="never" destination="cp-4" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=3..)" yaw="@0" pitch="@0" observers="never" destination="cp-4" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=..2)" yaw="@0" pitch="@0" observers="never" destination="cp-3" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=2..)" yaw="@0" pitch="@0" observers="never" destination="cp-3" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=..1)" yaw="@0" pitch="@0" observers="never" destination="cp-2" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=1..)" yaw="@0" pitch="@0" observers="never" destination="cp-2" sound="false" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=0)" yaw="@0" pitch="@0" observers="never" destination="cp-1" sound="false" />
-    <portal filter="not(participating)" yaw="@0" pitch="@0" region="void" destination="spawn-point" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=1)" x="58" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=2)" x="116" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=3)" x="174" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=4)" x="232" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=5)" x="290" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=6)" x="348" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=7)" x="406" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=8)" x="464" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=9)" x="522" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-9, tp_checkpoint=..8)" destination="cp-9" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=8..)" destination="cp-9" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=..7)" destination="cp-8" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=7..)" destination="cp-8" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=..6)" destination="cp-7" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=6..)" destination="cp-7" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=..5)" destination="cp-6" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=5..)" destination="cp-6" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=..4)" destination="cp-5" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=4..)" destination="cp-5" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=..3)" destination="cp-4" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=3..)" destination="cp-4" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=..2)" destination="cp-3" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=2..)" destination="cp-3" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=..1)" destination="cp-2" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=1..)" destination="cp-2" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=0)" destination="cp-1" />
+    <portal filter="not(participating)" region="void" destination="spawn-point" observers="always" />
 </portals>
 <filters>
     <!-- #region scores -->

--- a/arcade/standard/blockglitch_4/map.xml
+++ b/arcade/standard/blockglitch_4/map.xml
@@ -2,7 +2,8 @@
 <!-- #region meta -->
 <name>BlockGlitch 4</name>
 <slug>blockglitch_4_hell_edition</slug>
-<version>1.1.1</version>
+<!-- Commit ID: be9dd6ac464c4358640f7fa4903452abb4c19ae6 -->
+<version>1.1.2</version>
 <created>2023-10-22</created>
 <objective>Be the first one to finish the parkour!</objective>
 <phase>development</phase>
@@ -68,7 +69,8 @@
 <regions>
     <below y="60" id="void" />
     <!-- #region checkpoint-points -->
-    <point id="spawn">${SPAWN_LOCATION}</point>
+    <cuboid id="spawn" min="187,110,-17" max="235,112,-11" />
+    <point id="spawn-point">${SPAWN_LOCATION}</point>
     <union id="cp-10-union">
         <point id="cp-10">${CHECKPOINT_10}</point>
         <translate offset="58,0,0" region="cp-10" id="cp-10-2" />
@@ -384,7 +386,7 @@
             </union>
         </regions>
     </spawn>
-    <default>
+    <default safe="true">
         <regions>
             <region id="spawn" />
         </regions>
@@ -441,33 +443,33 @@
         to a single point determined by a randomized variable, and then we move them
         by a predetermined offset up to the desired destination.
     -->
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=1)" x="58" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=2)" x="116" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=3)" x="174" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=4)" x="232" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=5)" x="290" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=6)" x="348" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=7)" x="406" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=8)" x="464" observers="never" />
-    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=9)" x="522" observers="never" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-9, tp_checkpoint=..8)" yaw="@0" pitch="@0" observers="never" destination="cp-9" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=8..)" yaw="@0" pitch="@0" observers="never" destination="cp-9" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=..7)" yaw="@0" pitch="@0" observers="never" destination="cp-8" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=7..)" yaw="@0" pitch="@0" observers="never" destination="cp-8" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=..6)" yaw="@0" pitch="@0" observers="never" destination="cp-7" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=6..)" yaw="@0" pitch="@0" observers="never" destination="cp-7" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=..5)" yaw="@0" pitch="@0" observers="never" destination="cp-6" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=5..)" yaw="@0" pitch="@0" observers="never" destination="cp-6" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=..4)" yaw="@0" pitch="@0" observers="never" destination="cp-5" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=4..)" yaw="@0" pitch="@0" observers="never" destination="cp-5" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=..3)" yaw="@0" pitch="@0" observers="never" destination="cp-4" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=3..)" yaw="@0" pitch="@0" observers="never" destination="cp-4" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=..2)" yaw="@0" pitch="@0" observers="never" destination="cp-3" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=2..)" yaw="@0" pitch="@0" observers="never" destination="cp-3" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=..1)" yaw="@0" pitch="@0" observers="never" destination="cp-2" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=1..)" yaw="@0" pitch="@0" observers="never" destination="cp-2" />
-    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=0)" yaw="@0" pitch="@0" observers="never" destination="cp-1" />
-    <portal filter="not(participating)" yaw="@0" pitch="@0" region="void" destination="spawn" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=1)" x="58" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=2)" x="116" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=3)" x="174" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=4)" x="232" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=5)" x="290" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=6)" x="348" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=7)" x="406" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=8)" x="464" observers="never" sound="false" />
+    <portal forward="all(not(portal-debounce), do_tp=1, tp_lane=9)" x="522" observers="never" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-9, tp_checkpoint=..8)" yaw="@0" pitch="@0" observers="never" destination="cp-9" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=8..)" yaw="@0" pitch="@0" observers="never" destination="cp-9" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-8, tp_checkpoint=..7)" yaw="@0" pitch="@0" observers="never" destination="cp-8" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=7..)" yaw="@0" pitch="@0" observers="never" destination="cp-8" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-7, tp_checkpoint=..6)" yaw="@0" pitch="@0" observers="never" destination="cp-7" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=6..)" yaw="@0" pitch="@0" observers="never" destination="cp-7" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-6, tp_checkpoint=..5)" yaw="@0" pitch="@0" observers="never" destination="cp-6" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=5..)" yaw="@0" pitch="@0" observers="never" destination="cp-6" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-5, tp_checkpoint=..4)" yaw="@0" pitch="@0" observers="never" destination="cp-5" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=4..)" yaw="@0" pitch="@0" observers="never" destination="cp-5" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-4, tp_checkpoint=..3)" yaw="@0" pitch="@0" observers="never" destination="cp-4" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=3..)" yaw="@0" pitch="@0" observers="never" destination="cp-4" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-3, tp_checkpoint=..2)" yaw="@0" pitch="@0" observers="never" destination="cp-3" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=2..)" yaw="@0" pitch="@0" observers="never" destination="cp-3" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-2, tp_checkpoint=..1)" yaw="@0" pitch="@0" observers="never" destination="cp-2" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=1..)" yaw="@0" pitch="@0" observers="never" destination="cp-2" sound="false" />
+    <portal forward="all(portal-debounce, do_tp=2, lvl-1, tp_checkpoint=0)" yaw="@0" pitch="@0" observers="never" destination="cp-1" sound="false" />
+    <portal filter="not(participating)" yaw="@0" pitch="@0" region="void" destination="spawn-point" sound="false" />
 </portals>
 <filters>
     <!-- #region scores -->
@@ -520,9 +522,14 @@
     <participating id="participating" />
     <!--
         HACK: This clock allows PGM to breathe a bit and teleport you to a
-        random lane properly
+        random lane properly.
+
+        This debouncing clock also tries its best to mitigate client-side
+        chunk rendering issues after being teleported twice. It is a last 
+        resort before causing nerve loss, and resorting to implementing the
+        teleports via criminally infamous 340 portal nodes.
     -->
-    <pulse id="portal-debounce" period="0.1s" duration="0.05s" filter="running" />
+    <pulse id="portal-debounce" period="0.4s" duration="0.2s" filter="running" />
 </filters>
 <consumables>
     <consumable id="on-potion-drink" on="eat" action="set-tp" />
@@ -533,10 +540,10 @@
         <set var="tp_checkpoint" value="tp_checkpoint + 1" />
     </action>
     <action id="randomize-tp-lane" scope="player">
-        <set var="tp_lane" value="floor(random() * 9)" />
+        <set var="tp_lane" value="floor(random() * 10)" />
     </action>
     <action id="set-tp" scope="player">
-        <set var="tp_lane" value="floor(random() * 9)" />
+        <set var="tp_lane" value="floor(random() * 10)" />
         <set var="do_tp" value="2" />
     </action>
     <action id="decrease-tp" scope="player">
@@ -582,7 +589,7 @@
     <!-- #endregion triggers-kits -->
     <!-- #region triggers-auto-tp -->
     <trigger filter="running" scope="player" action="randomize-tp-lane" />
-    <trigger filter="void" scope="player" action="set-tp" />
+    <trigger filter="all(void, participating)" scope="player" action="set-tp" />
     <trigger filter="all(portal-debounce, do_tp=1, cp-boxes)" scope="player" action="decrease-tp" />
     <trigger filter="all(not(portal-debounce), do_tp=2, cp-boxes)" scope="player" action="decrease-tp" />
     <trigger filter="all(cp-boxes, participating)" scope="player" action="remove-respawn-potion" />


### PR DESCRIPTION
- Fixed an issue where jumping into the void set the teleportation variables, causing you to be teleported into the ever after after match start, and in the end, kicked from the server for flying.
- Adjusted portal debouncing to help mitigate client-side chunk rendering issues after teleporting at the expense of double teleportation being more visible to the player. In an ideal case, the player would get teleported only once, however, at the current state of PGM, this would bring the map declaration to a total of over 340 portal nodes, making maintaining the map by hand unsustainable in the long-term.
- Fixed an oversight causing the 10th lane to be practically unused for the rest of the match due to it being outside the RNG bounds.
- The initial spawn region has been expanded to the entirety of the "Focus Beanes" sign.
- Silenced all portals on the map as the sound effect seems to be global and I don't find it quite making sense to have it like that.

Ref: #836