### PR TITLE
Watch Your Head: 1.0.1

### DIFF
--- a/arcade/standard/watch_your_head/map.xml
+++ b/arcade/standard/watch_your_head/map.xml
@@ -1,8 +1,8 @@
 <map proto="1.4.2">
 <!-- #region meta -->
 <name>Watch Your Head</name>
-<!-- Commit ID: 6ca8a189a8180b1ddba0a36f503a68923649e177 -->
-<version>1.0.0</version>
+<!-- Commit ID: 7309dfbb4c7715e36b9c4cf0be9d1c562ebcbdba -->
+<version>1.0.1</version>
 <created>2023-11-11</created>
 <objective>Be the first team to reach ${MAX_POINT_AMOUNT} points!</objective>
 <phase>development</phase>
@@ -49,7 +49,7 @@
 </variables>
 <respawn delay="0s" auto="true" spectate="true">
     <message>
-        You will respawn once the rest of your team dies.
+        You will respawn once the teams switch.
     </message>
 </respawn>
 <score>
@@ -92,12 +92,12 @@
     <apply leave="is_defending=1" message="You may not leave the anthill!" region="the-anthill" />
 </regions>
 <spawns>
-    <spawn filter="all(game_stage=0, only-blue)" kit="stage-0-kit">
+    <spawn filter="all(game_stage=0, only-blue, not(match-started-debounce))" kit="stage-0-kit">
         <regions yaw="-45" pitch="0">
             <point>0.5,42.0,4.5</point>
         </regions>
     </spawn>
-    <spawn filter="all(game_stage=0, only-red)" kit="stage-0-kit">
+    <spawn filter="all(game_stage=0, only-red, not(match-started-debounce))" kit="stage-0-kit">
         <regions yaw="45" pitch="0">
             <point>28.5,42.0,32.5</point>
         </regions>
@@ -283,7 +283,7 @@
     <trigger filter="all(participating, not(alive))" scope="player" action="set-dead" />
     <!-- Hide the TNT minecart moderation layer for aesthetical purposes -->
     <trigger filter="always" scope="match" action="hide-tnt-moderator" />
-    <trigger filter="all(game_stage=1)" scope="match" action="place-tnt-moderator" />
+    <trigger filter="game_stage=1" scope="match" action="place-tnt-moderator" />
 </actions>
 <hunger>
     <depletion>off</depletion>


### PR DESCRIPTION
- Disallows players from spawning in the match after the initial stage has started. This also fixes an issue where the match would lock up at the initial stage if the match wasn't a 1v1 match.
- The respawn message was rewritten to be more appropriate in cases when the player joins midgame.

Ref: #856 