### PR TITLE
Wintertime: expand middle region

### DIFF
--- a/ctw/standard/wintertime/map.xml
+++ b/ctw/standard/wintertime/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Wintertime</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <objective>Capture the enemy team's wool!</objective>
 <created>2023-05-12</created>
 <authors>
@@ -121,7 +121,7 @@
             <rectangle min="-14,-6" max="8,9"/>
             <rectangle min="-13,34" max="18,19"/>
             <!-- Middle -->
-            <rectangle min="-31,7" max="-13,21"/>
+            <rectangle min="-31,6" max="-13,22"/>
         </union>
     </negative>
     <point id="blue-wool-spawn">56.5,12,50.5</point>


### PR DESCRIPTION
Fixes the issue where a 1 wide region on the middle islands was counted as void