### PR TITLE
Peloponnesia: Region Fixes, Item Removes

### DIFF
--- a/ctw/standard/peloponnesia/map.xml
+++ b/ctw/standard/peloponnesia/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Peloponnesia</name>
-<version>1.2.2</version>
+<version>1.2.3</version>
 <gamemode>ctw</gamemode>
 <created>2023-07-20</created>
 <objective>Capture the wools and rewrite history</objective>
@@ -943,11 +943,11 @@
             <rectangle min="31,-67" max="25,61"/> <!-- red tiny patch -->
             <rectangle min="-109,-55" max="-150,-40"/> <!-- orange wool area -->
             <rectangle min="-116,-40" max="-97,-4"/> <!-- orange wool shortcut area -->
-            <rectangle min="-109,56" max="-151,40"/> <!-- pink wool area -->
+            <rectangle min="-109,56" max="-151,41"/> <!-- pink wool area -->
             <rectangle min="-116,41" max="-97,4"/> <!-- pink wool shortcut area -->
             <rectangle min="110,-55" max="151,-40"/> <!-- lime wool area -->
             <rectangle min="117,-40" max="98,-4"/> <!-- lime wool shortcut area -->
-            <rectangle min="110,56" max="152,37"/> <!-- light blue wool area -->
+            <rectangle min="110,56" max="152,41"/> <!-- light blue wool area -->
             <rectangle min="117,41" max="98,4"/> <!-- light blue wool shortcut area -->
         </union>
     </negative>
@@ -1022,6 +1022,14 @@
     <item>leather helmet</item>
     <item>leather leggings</item>
     <item>leather boots</item>
+    <item>chainmail helmet</item>
+    <item>chainmail chestplate</item>
+    <item>chainmail leggings</item>
+    <item>chainmail boots</item>
+    <item>iron helmet</item>
+    <item>iron chestplate</item>
+    <item>iron leggings</item>
+    <item>iron boots</item>
 </itemremove>
 <hunger>
     <depletion>off</depletion>


### PR DESCRIPTION
Fixes a couple of problems reported recently:
- Wool room courtyard regions were too large one side, mainly one wool room
- Armor drops removed since kits are upgrade based