### PR TITLE
Shroom Galaxy: Expand spawn regions

### DIFF
--- a/ctw/standard/shroom_galaxy/map.xml
+++ b/ctw/standard/shroom_galaxy/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Shroom Galaxy</name>
-<version>1.1.1</version>
+<version>1.1.2</version>
 <objective>Capture the two wools of the enemy team!</objective>
 <include id="gapple-kill-reward"/>
 <created>2022-09-23</created>
@@ -92,8 +92,8 @@
 </filters>
 <regions>
     <union id="spawns">
-        <rectangle id="red-spawn" min="184,72" max="238,17"/>
-        <rectangle id="blue-spawn" min="-35,17" max="-89,72"/>
+        <rectangle id="red-spawn" min="184,73" max="238,16"/>
+        <rectangle id="blue-spawn" min="-35,16" max="-89,73"/>
     </union>
     <union id="iron-renewables">
         <union id="red-iron">


### PR DESCRIPTION
Prevents players from the other team from walking on the edge and jumping into woolroom