### PR TITLE
Apple Smash - Refinements

### DIFF
--- a/dtcm/apple_smash/map.xml
+++ b/dtcm/apple_smash/map.xml
@@ -13,8 +13,8 @@ Features:
 - Auto-ignite TNT available as kill reward or purchase in the Player store
 -->
 <name>Apple Smash</name>
-<version>1.2.0</version>
-<phase>staging</phase>
+<version>1.2.1</version>
+<include id="gapple-kill-reward"/>
 <objective>Destroy the enemy's Apples!</objective>
 <gamemode>dtm</gamemode>
 <created>2023-11-01</created>
@@ -27,8 +27,8 @@ Features:
 </world>
 <teams>
     <!-- Cyan instead of green to help R/G colorblind -->
-    <team id="green-team" color="dark_aqua" max="22" max-overfill="50">Mutsu</team> <!-- Green -->
-    <team id="red-team" color="red" max="22" max-overfill="50">Fuji</team> <!-- Red -->
+    <team id="green-team" color="dark_aqua" max="22">Mutsu</team> <!-- Green -->
+    <team id="red-team" color="red" max="22">Fuji</team> <!-- Red -->
 </teams>
 <kits>
     <kit id="spawn-kit" force="true">
@@ -41,7 +41,7 @@ Features:
         <item slot="2" material="iron pickaxe" unbreakable="true"/>
         <item slot="3" material="stone axe" unbreakable="true"/>
         <item slot="4" material="stone spade"/>
-        <item slot="5" material="log" amount="16"/>
+        <item slot="5" material="wood" amount="64"/>
         <item slot="6" material="smooth brick" amount="16"/>
         <item slot="7" material="bucket"/>
         <item slot="8" material="golden apple"/>
@@ -229,17 +229,17 @@ Features:
 </default>
 </spawns>
 <broadcasts>
-<alert filter="only-green" after="2s">`r`7`lKon'nichiwa Samurai, defend the Green Apples and destroy the Red Apples.`r</alert>
-<alert filter="only-red" after="2s">`r`7`lKon'nichiwa Samurai, defend the Red Apples and destroy the Green Apples.`r</alert>
-<alert filter="only-green" after="20s">`r`7`lCollect Redstone and Emerald blocks for store upgrades.`r</alert>
-<alert filter="only-red" after="20s">`r`7`lCollect Emerald and Redstone blocks for store upgrades.`r</alert>
-<tip after="60s" every="3m">`r`7`lDiamond Chestplates from the center will last for your current life and 3 additional lives.`r</tip>
-<tip after="90s" every="3m" filter="only-green">`r`7`lPermanent diamond helmet awarded for collecting a monument block while on a Red Apple.`r</tip>
-<tip after="90s" every="3m" filter="only-red">`r`7`lPermanent diamond helmet awarded for collecting a monument block while on a Green Apple.`r</tip>
-<tip after="180s" every="3m">`r`7`lYour Apple cannot be repaired, but dropped blocks can buy upgrades in the store.`r</tip>
-<tip after="210s" every="3m">`r`7`lTNT awarded for every 4 kills, or buy TNT in the store.`r</tip>
-<tip after="720s">`r`7`lDid you know? "Ringo" is Japanese for Apple.`r</tip>
-<tip after="900s">`r`7`lDid you know? Fuji and Mutsu Apples are named after places in Japan.`r</tip>
+<alert filter="only-green" after="2s">`r`f`lKon'nichiwa Samurai, defend the Green Apples and destroy the Red Apples.`r</alert>
+<alert filter="only-red" after="2s">`r`f`lKon'nichiwa Samurai, defend the Red Apples and destroy the Green Apples.`r</alert>
+<alert filter="only-green" after="20s">`r`f`lCollect Redstone and Emerald blocks for store upgrades.`r</alert>
+<alert filter="only-red" after="20s">`r`f`lCollect Emerald and Redstone blocks for store upgrades.`r</alert>
+<tip after="60s" every="5m">`r`b`lDiamond Chestplates from the center will last for your current life and 3 additional lives.`r</tip>
+<tip after="90s" every="6m" filter="only-green">`r`b`lPermanent diamond helmet awarded for collecting a monument block while on a Red Apple.`r</tip>
+<tip after="90s" every="6m" filter="only-red">`r`b`lPermanent diamond helmet awarded for collecting a monument block while on a Green Apple.`r</tip>
+<tip after="180s" every="8m">`r`b`lYour Apple cannot be repaired, but dropped blocks can buy upgrades in the store.`r</tip>
+<tip after="250s" every="8m">`r`c`lTNT awarded for every 4 kills, or buy TNT in the store.`r</tip>
+<tip after="720s">`r`f`lDid you know? "Ringo" is Japanese for Apple.`r</tip>
+<tip after="900s">`r`f`lDid you know? Fuji and Mutsu Apples are named after places in Japan.`r</tip>
 </broadcasts>
 <shopkeepers name="`2`lPlayer Upgrades" shop="red-player-shop"> <!-- On Left -->
     <shopkeeper mob="Villager" yaw="90">-134.5,52,-7.5</shopkeeper> <!-- Red -->
@@ -734,20 +734,21 @@ Features:
     <action id="block-boost-action-1" scope="player">
         <set var="block_boost_variable" value="1"/>
         <message text="`e`l▲ `6Team kit upgraded to `e`lBlock Boost I`r"/>
-        <kit force="true" filter="always" deduct-items="true">
-            <item material="log" amount="32"/>
-            <item material="smooth brick" amount="32"/>
-            <item material="wool" amount="32" team-color="true"/>
+        <kit force="true" filter="always" deduct-items="false">
+            <item material="wood" amount="64"/>
+            <item material="smooth brick" amount="16"/>
+            <item material="wool" amount="16" team-color="true"/>
         </kit>
         <set var="upgrade_me_variable" value="1"/>
     </action>
     <action id="block-boost-action-2" scope="player">
         <set var="block_boost_variable" value="2"/>
         <message text="`e`l▲ `6Team kit upgraded to `e`lBlock Boost II`r"/>
-        <kit force="true" filter="always" deduct-items="true">
-            <item material="log" amount="64"/>
-            <item material="smooth brick" amount="64"/>
-            <item material="wool" amount="64" team-color="true"/>
+        <kit force="true" filter="always" deduct-items="false">
+            <item material="wood" amount="64"/>
+            <item material="wood" amount="64"/>
+            <item material="smooth brick" amount="32"/>
+            <item material="wool" amount="32" team-color="true"/>
         </kit>
         <set var="upgrade_me_variable" value="1"/>
     </action>
@@ -1130,7 +1131,7 @@ Features:
     <trigger filter="respawn-reset-phase-1-done" trigger="reset-stuff-part-2" scope="player"/>
     <action id="tnt-action" scope="player">
         <kit force="true" filter="always" deduct-items="false">
-            <item material="tnt" amount="1"/>
+            <item material="tnt" amount="2"/>
         </kit>
     </action>
     <action id="god-apple-action" scope="player">
@@ -1258,14 +1259,16 @@ Features:
             <item material="diamond sword" unbreakable="true" enchantment="sharpness:2"/>
         </kit>
         <!-- Reset: Block Boost 1 Upgrade -->
-        <kit force="true" filter="block-boost-1">
-            <item material="log" amount="16"/>
+        <kit force="true" filter="block-boost-1" deduct-items="true">
+            <item material="wood" amount="64"/>
             <item material="smooth brick" amount="16"/>
             <item material="wool" amount="16" team-color="true"/>
         </kit>
         <!-- Reset: Block Boost 2 Upgrade -->
-        <kit force="true" filter="block-boost-2">
-            <item material="log" amount="48"/>
+        <kit force="true" filter="block-boost-2" deduct-items="true">
+            <item material="wood" amount="64"/>
+            <item material="wood" amount="64"/>
+            <item material="wood" amount="64"/>
             <item material="smooth brick" amount="48"/>
             <item material="wool" amount="48" team-color="true"/>
         </kit>
@@ -1322,7 +1325,7 @@ Features:
         </kit>
         <set var="reset_phase_variable" value="1"/> <!-- triggers part 2 -->
     </action>
-    <trigger filter="respawned" trigger="reset-stuff-part-1" scope="player"/>
+    <trigger filter="alive" trigger="reset-stuff-part-1" scope="player"/>
     <action id="dead-action" scope="player">
         <set var="reset_phase_variable" value="0"/>
     </action>
@@ -1362,7 +1365,7 @@ Features:
 <filters>
     <team id="only-green">green-team</team>
     <team id="only-red">red-team</team>
-    <alive id="respawned"/>
+    <alive id="alive"/>
     <dead id="dead"/>
     <any id="block-break-void-filter">
         <all>
@@ -1395,6 +1398,7 @@ Features:
     </after>
     <!-- Auto equip the diamond chestplate -->
     <all id="chestplate-holding">
+        <alive/>
         <not>
             <wearing ignore-metadata="true">
                 <item material="diamond chestplate"/>
@@ -1406,6 +1410,7 @@ Features:
     </all>
     <!-- Auto remove extra chestplates from inventory -->
     <all id="chestplate-hoarding">
+        <alive/>
         <wearing ignore-metadata="true">
             <item material="diamond chestplate"/>
         </wearing>
@@ -1419,6 +1424,7 @@ Features:
     </after>
     <!-- Chestplate life is depleted -->
     <all id="vanity-chestplate-done">
+        <alive/> <!-- no way observers should match, but PGM oversharing -->
         <variable var="vanity_chestplate_variable">1</variable>
         <variable var="vanity_chestplate_life_variable">0</variable>
     </all>
@@ -1884,7 +1890,7 @@ Features:
         <!-- One-time Items -->
         <category id="player" name="`aItem Store" material="tnt">
             <item material="apple" name="`2Knockbapple II" enchantment="knockback:2" amount="1" price="5" currency="emerald block" color="dark green" action="knockback-apple-action" lore="`7One-time purchase:|`71 Knockbapple with Knockback II.|"/>
-            <item material="tnt" damage="1" name="`2TNT" amount="1" price="7" currency="emerald block" color="dark green" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
+            <item material="tnt" damage="1" name="`2TNT" amount="2" price="7" currency="emerald block" color="dark green" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
             <item material="golden_apple" name="`2God Apples" damage="1" amount="3" price="24" currency="emerald block" color="dark green" action="god-apple-action" lore="`7One-time purchase:|`73 Enchanted Golden Apples.|"/>
         </category>
     </shop>
@@ -1958,7 +1964,7 @@ Features:
         <!-- One-time Items -->
         <category id="player" name="`aItem Store" material="tnt">
             <item material="apple" name="`2Knockbapple II" enchantment="knockback:2" amount="1" price="5" currency="redstone block" color="red" action="knockback-apple-action" lore="`7One-time purchase:|`71 Knockbapple with Knockback II.|"/>
-            <item material="tnt" damage="1" name="`2TNT" amount="1" price="7" currency="redstone block" color="red" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
+            <item material="tnt" damage="1" name="`2TNT" amount="2" price="7" currency="redstone block" color="red" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
             <item material="golden_apple" name="`2God Apples" damage="1" amount="3" price="24" currency="redstone block" color="red" action="god-apple-action" lore="`7One-time purchase:|`73 Enchanted Golden Apples.|"/>
         </category>
     </shop>
@@ -1991,7 +1997,7 @@ Features:
         </category>
     </shop>
 </shops>
-<destroyables materials="emerald block;redstone block" mode-changes="false" sparks="true" repairable="false" show-progress="true" required="true" completion="94%">
+<destroyables materials="emerald block;redstone block" mode-changes="false" sparks="true" repairable="false" show-progress="true" required="true" completion="95%">
     <destroyable id="red-apple-1" name="Red Apple L" owner="red-team">
         <region><cuboid id="red-monument-1" min="-62,49,-29" max="-69,58,-22"/></region>
     </destroyable>
@@ -2019,17 +2025,17 @@ Features:
     </rule>
 </block-drops>
 <spawners player-region="everywhere">
-    <spawner spawn-region="green-monument-1" max-entities="2" delay="30s">
-        <item amount="1" material="emerald block"/>
+    <spawner spawn-region="green-monument-1" max-entities="4" delay="30s">
+        <item amount="2" material="emerald block"/>
     </spawner>
-    <spawner spawn-region="green-monument-2" max-entities="2" delay="30s">
-        <item amount="1" material="emerald block"/>
+    <spawner spawn-region="green-monument-2" max-entities="4" delay="30s">
+        <item amount="2" material="emerald block"/>
     </spawner>
-    <spawner spawn-region="red-monument-1" max-entities="2" delay="30s">
-        <item amount="1" material="redstone block"/>
+    <spawner spawn-region="red-monument-1" max-entities="4" delay="30s">
+        <item amount="2" material="redstone block"/>
     </spawner>
-    <spawner spawn-region="red-monument-2" max-entities="2" delay="30s">
-        <item amount="1" material="redstone block"/>
+    <spawner spawn-region="red-monument-2" max-entities="4" delay="30s">
+        <item amount="2" material="redstone block"/>
     </spawner>
 </spawners>
 <regions>
@@ -2117,18 +2123,17 @@ Features:
     <friendly-defuse>off</friendly-defuse>
     <fuse>3s</fuse>
     <yield>1</yield>
-    <power>2.4</power>
+    <power>2.5</power>
 </tnt>
 <disabledamage>
     <damage ally="true" self="false" enemy="false" other="false">block explosion</damage>
 </disabledamage>
 <kill-rewards>
     <kill-reward>
-        <item material="golden apple" amount="1"/>
-        <item material="smooth brick" amount="8"/>
+        <item material="smooth brick" amount="16"/>
     </kill-reward>
     <kill-reward>
-        <item material="tnt" amount="1"/>
+        <item material="tnt" amount="2"/>
         <filter>
             <kill-streak count="4" repeat="true"/>
         </filter>


### PR DESCRIPTION
- Logs -> Wood
- Added alive to some filters to prevent PGM leaking sounds to observers that weren't matching filter already
- Added gapple include
- Added simple colors to some broadcasts
- Doubled spawner block drops
- Doubled kill rewards (TNT/blocks), also doubled TNT in store
- Remove staging