### PR TITLE
Bed Rush - Minor Adjustments

### DIFF
--- a/arcade/standard/bed_rush/map.xml
+++ b/arcade/standard/bed_rush/map.xml
@@ -117,7 +117,8 @@
     <after id="countdown" filter="all(resetting,match-running)" duration="2.8s"/>
     <after id="resetting-kit" filter="all(resetting,alive,match-running)" duration="1.8s"/>
     <after id="should-tp" filter="all(resetting,match-running)" duration="1.85s"/>
-    <after id="turn-on-fall-damage" filter="running" duration="7s"/> <!-- prevents shared fall damage when many players land together -->
+    <!-- prevents shared fall damage when many players land together at start -->
+    <after id="turn-on-fall-damage" filter="running" duration="7s"/>
     <any id="red-bed-broke">
         <offset vector="0,10,-41">
             <material>air</material>

--- a/arcade/standard/bed_rush/map.xml
+++ b/arcade/standard/bed_rush/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.4.2">
 <name>Bed Rush</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
+<include id="gapple-kill-reward"/>
 <objective>Destroy the Bed to win the Round. First Team to 5 Wins!</objective>
 <created>2024-07-01</created>
 <authors>
@@ -116,7 +117,7 @@
     <after id="countdown" filter="all(resetting,match-running)" duration="2.8s"/>
     <after id="resetting-kit" filter="all(resetting,alive,match-running)" duration="1.8s"/>
     <after id="should-tp" filter="all(resetting,match-running)" duration="1.85s"/>
-    <after id="turn-on-fall-damage" filter="running" duration="5s"/>
+    <after id="turn-on-fall-damage" filter="running" duration="7s"/> <!-- prevents shared fall damage when many players land together -->
     <any id="red-bed-broke">
         <offset vector="0,10,-41">
             <material>air</material>
@@ -182,7 +183,6 @@
     <action id="bad-sounds" scope="team">
         <sound key="mob.enderdragon.growl" volume="1" pitch="1"/>
         <sound key="mob.enderdragon.growl" volume="1" pitch=".9"/>
-        <sound key="mob.enderdragon.growl" volume="1" pitch=".8"/>
         <sound preset="objective_bad" volume=".3" pitch="1"/>
     </action>
     <!-- Winning message shown to all: observers, red and blue teams -->
@@ -334,7 +334,7 @@
 <regions>
     <!-- course boundaries -->
     <below id="void" y="0"/>
-    <above y="23" id="ceiling"/>
+    <above y="24" id="ceiling"/>
     <union id="no-go">
         <cuboid id="zone-1a" min="12,23,20" max="13,1,44"/>
         <cuboid id="zone-1b" min="12,23,-43" max="13,1,-19"/>
@@ -395,7 +395,6 @@
 </itemremove>
 <kill-rewards>
     <kill-reward>
-        <item material="golden apple"/>
         <item material="wood" amount="16"/>
         <item material="sandstone" damage="2" amount="16"/>
     </kill-reward>


### PR DESCRIPTION
Increase player ceiling by 1 to prevent occasional bumping off it

Reduce sound volume for ender dragon growl

Extended fall damage filter slightly, just to be sure

Gapple Kill Reward Include