### PR TITLE
Apple Smash - Fix Stacking, Store updates, etc

### DIFF
--- a/dtcm/apple_smash/map.xml
+++ b/dtcm/apple_smash/map.xml
@@ -231,15 +231,15 @@ Features:
 <broadcasts>
 <alert filter="only-green" after="2s">`r`f`lKon'nichiwa Samurai, defend the Green Apples and destroy the Red Apples.`r</alert>
 <alert filter="only-red" after="2s">`r`f`lKon'nichiwa Samurai, defend the Red Apples and destroy the Green Apples.`r</alert>
-<alert filter="only-green" after="20s">`r`f`lCollect Redstone and Emerald blocks for store upgrades.`r</alert>
-<alert filter="only-red" after="20s">`r`f`lCollect Emerald and Redstone blocks for store upgrades.`r</alert>
-<tip after="60s" every="5m">`r`b`lDiamond Chestplates from the center will last for your current life and 3 additional lives.`r</tip>
+<alert filter="only-green" after="20s">`r`f`lCollect Redstone and Emerald blocks for upgrade shops.`r</alert>
+<alert filter="only-red" after="20s">`r`f`lCollect Emerald and Redstone blocks for upgrade shops.`r</alert>
+<tip after="60s" every="6m">`r`b`lDiamond Chestplates from the center will last for your current life and 3 additional lives.`r</tip>
 <tip after="90s" every="6m" filter="only-green">`r`b`lPermanent diamond helmet awarded for collecting a monument block while on a Red Apple.`r</tip>
 <tip after="90s" every="6m" filter="only-red">`r`b`lPermanent diamond helmet awarded for collecting a monument block while on a Green Apple.`r</tip>
 <tip after="180s" every="8m">`r`b`lYour Apple cannot be repaired, but dropped blocks can buy upgrades in the store.`r</tip>
 <tip after="250s" every="8m">`r`c`lTNT awarded for every 4 kills, or buy TNT in the store.`r</tip>
-<tip after="720s">`r`f`lDid you know? "Ringo" is Japanese for Apple.`r</tip>
-<tip after="900s">`r`f`lDid you know? Fuji and Mutsu Apples are named after places in Japan.`r</tip>
+<tip after="950s">`r`f`lDid you know? "Ringo" is Japanese for Apple.`r</tip>
+<tip after="1250s">`r`f`lDid you know? Fuji and Mutsu Apples are named after places in Japan.`r</tip>
 </broadcasts>
 <shopkeepers name="`2`lPlayer Upgrades" shop="red-player-shop"> <!-- On Left -->
     <shopkeeper mob="Villager" yaw="90">-134.5,52,-7.5</shopkeeper> <!-- Red -->
@@ -342,137 +342,38 @@ Features:
         <set var="vanity_chestplate_life_variable" value="0"/>
     </action>
     <trigger filter="vanity-chestplate-done" trigger="vanity-chestplate-done-action" scope="player"/>
-    <!-- Since blocks don't stack well, at least warn the player to manually stack -->
-    <action id="redstone-pickup-warning-action" scope="player">
-        <message text="`4`l▲ `cRestack Red blocks to prevent 'full' inventory!`r"/>
-        <sound key="note.bass" pitch=".891" volume=".1"/>
-        <sound key="note.pling" pitch=".891" volume="1"/>
-        <sound key="note.pling" pitch="1.335" volume="1"/>
-    </action>
-    <trigger filter="redstone-pickup-warning" action="redstone-pickup-warning-action" scope="player"/>
-    <action id="emerald-pickup-warning-action" scope="player">
-        <message text="`4`l▲ `cRestack Green blocks to prevent 'full' inventory!`r"/>
-        <sound key="note.bass" pitch=".891" volume=".1"/>
-        <sound key="note.pling" pitch=".891" volume="1"/>
-        <sound key="note.pling" pitch="1.335" volume="1"/>
-    </action>
-    <trigger filter="emerald-pickup-warning" action="emerald-pickup-warning-action" scope="player"/>
-    <!-- BY RED -->
-    <!-- Red picks up plain redstone -->
+    <!-- Red picks up redstone -->
     <action id="pickup-red-action-by-red" scope="player">
         <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_red_momentary_variable" value="1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="redstone block"/>
-            <replace material="redstone block" name="Red Recovered block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-red-filter-by-red" action="pickup-red-action-by-red" scope="player"/>
-    <!-- Red picks up stolen redstone -->
-    <action id="pickup-red2-action-by-red" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_red_momentary_variable" value="1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="redstone block" name="Red Stolen block"/>
-            <replace material="redstone block" name="Red Recovered block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-red2-filter-by-red" action="pickup-red2-action-by-red" scope="player"/>
-    <!-- Red picks up vanilla emerald -->
-    <action id="pickup-green-action-by-red" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_green_momentary_variable" value="1"/>
-        <set var="pickup_enemy_count" value="pickup_enemy_count+1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="emerald block"/>
-            <replace material="emerald block" name="Green Stolen block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-green-filter-by-red" action="pickup-green-action-by-red" scope="player"/>
-    <!-- Red picks up recovered emerald -->
-    <action id="pickup-green2-action-by-red" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_green_momentary_variable" value="1"/>
-        <set var="pickup_enemy_count" value="pickup_enemy_count+1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="emerald block" name="Green Recovered block"/>
-            <replace material="emerald block" name="Green Stolen block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-green2-filter-by-red" action="pickup-green2-action-by-red" scope="player"/>
-    <!-- By GREEN -->
-    <!-- Green picks up plain emerald -->
-    <action id="pickup-green-action-by-green" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_green_momentary_variable" value="1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="emerald block"/>
-            <replace material="emerald block" name="Green Recovered block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-green-filter-by-green" action="pickup-green-action-by-green" scope="player"/>
-    <!-- Green picks up stolen emerald -->
-    <action id="pickup-green2-action-by-green" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_green_momentary_variable" value="1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="emerald block" name="Green Stolen block"/>
-            <replace material="emerald block" name="Green Recovered block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-green2-filter-by-green" action="pickup-green2-action-by-green" scope="player"/>
-    <!-- Green picks up vanilla redstone -->
-    <action id="pickup-red-action-by-green" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_red_momentary_variable" value="1"/>
-        <set var="pickup_enemy_count" value="pickup_enemy_count+1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="redstone block"/>
-            <replace material="redstone block" name="Red Stolen block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-red-filter-by-green" action="pickup-red-action-by-green" scope="player"/>
-    <!-- Green picks up recovered redstone -->
-    <action id="pickup-red2-action-by-green" scope="player">
-        <sound key="random.levelup" volume=".9" pitch="1.2"/>
-        <set var="pickup_red_momentary_variable" value="1"/>
-        <set var="pickup_enemy_count" value="pickup_enemy_count+1"/>
-        <replace-item ignore-metadata="false" keep-amount="true">
-            <find material="redstone block" name="Red Recovered block"/>
-            <replace material="redstone block" name="Red Stolen block"/>
-        </replace-item>
-    </action>
-    <trigger filter="pickup-red2-filter-by-green" action="pickup-red2-action-by-green" scope="player"/>
-    <action id="red-pickup-red-action" scope="player">
         <sound key="entity.firework.twinkle" volume="1" pitch="1.22"/>
-        <set var="pickup_me_variable" value="1"/>
         <message text="`e`l▲ `6Purchase `lteam upgrades`r`6 with Red blocks in the store!`r"/>
     </action>
-    <trigger filter="red-pickup-red-filter" action="red-pickup-red-action" scope="player"/>
-    <action id="green-pickup-green-action" scope="player">
+    <trigger filter="pickup-red-filter-by-red" action="pickup-red-action-by-red" scope="player"/>
+    <!-- Red picks up emerald -->
+    <action id="pickup-green-action-by-red" scope="player">
+        <sound key="random.levelup" volume=".9" pitch="1.2"/>
+        <sound key="fireworks.launch" volume="1" pitch="1"/>
+        <sound key="fireworks.launch" volume="1" pitch=".9"/>
+        <sound key="fireworks.launch" volume="1" pitch=".5"/>
+        <message text="`e`l▲ `6Take Green blocks to store for `lplayer upgrades`r`6!`r"/>
+    </action>
+    <trigger filter="pickup-green-filter-by-red" action="pickup-green-action-by-red" scope="player"/>
+    <!-- Green picks up emerald -->
+    <action id="pickup-green-action-by-green" scope="player">
+        <sound key="random.levelup" volume=".9" pitch="1.2"/>
         <sound key="entity.firework.twinkle" volume="1" pitch="1.22"/>
-        <set var="pickup_me_variable" value="1"/>
         <message text="`e`l▲ `6Purchase `lteam upgrades`r`6 with Green blocks in the store!`r"/>
     </action>
-    <trigger filter="green-pickup-green-filter" action="green-pickup-green-action" scope="player"/>
-    <action id="red-pickup-green-action" scope="player">
-        <sound key="entity.firework.twinkle" volume="1" pitch="1.22"/>
-        <set var="pickup_them_variable" value="1"/>
-        <message text="`e`l▲ `6Take the Green block to store for `lplayer upgrades`r`6!`r"/>
+    <trigger filter="pickup-green-filter-by-green" action="pickup-green-action-by-green" scope="player"/>
+    <!-- Green picks up redstone -->
+    <action id="pickup-red-action-by-green" scope="player">
+        <sound key="random.levelup" volume=".9" pitch="1.2"/>
+        <sound key="fireworks.launch" volume="1" pitch="1"/>
+        <sound key="fireworks.launch" volume="1" pitch=".9"/>
+        <sound key="fireworks.launch" volume="1" pitch=".5"/>
+        <message text="`e`l▲ `6Take Red blocks to store for `lplayer upgrades`r`6!`r"/>
     </action>
-    <trigger filter="red-pickup-green-filter" action="red-pickup-green-action" scope="player"/>
-    <action id="green-pickup-red-action" scope="player">
-        <sound key="entity.firework.twinkle" volume="1" pitch="1.22"/>
-        <set var="pickup_them_variable" value="1"/>
-        <message text="`e`l▲ `6Take the Red block to store for `lplayer upgrades`r`6!`r"/>
-    </action>
-    <trigger filter="green-pickup-red-filter" action="green-pickup-red-action" scope="player"/>
-    <action id="pickup-red-momentary-action" scope="player">
-        <set var="pickup_red_momentary_variable" value="0"/>
-    </action>
-    <action id="pickup-green-momentary-action" scope="player">
-        <set var="pickup_green_momentary_variable" value="0"/>
-    </action>
+    <trigger filter="pickup-red-filter-by-green" action="pickup-red-action-by-green" scope="player"/>
     <action id="upgrade-me-action-2" scope="player">
         <sound key="random.orb" volume="1" pitch="1"/>
     </action>
@@ -481,14 +382,11 @@ Features:
         <sound key="random.anvil_use" volume=".2" pitch="1.2"/>
         <set var="upgrade_me_variable" value="0"/>
     </action>
-    <trigger filter="pickup-green-momentary" action="pickup-green-momentary-action" scope="player"/>
-    <trigger filter="pickup-red-momentary" action="pickup-red-momentary-action" scope="player"/>
     <trigger filter="upgrade-me-2" action="upgrade-me-action-2" scope="player"/>
     <trigger filter="upgrade-me-1" action="upgrade-me-action-1" scope="player"/>
     <trigger filter="vanity-hat-filter" action="vanity-hat-action" scope="player"/>
     <!-- Upgrade variables -->
     <set id="haste-set-1" var="haste_variable" value="1" scope="player"/>
-    <set id="haste-set-2" var="haste_variable" value="2" scope="player"/>
     <set id="sharpness-set-1" var="sharpness_variable" value="1" scope="player"/>
     <set id="sharpness-set-2" var="sharpness_variable" value="2" scope="player"/>
     <set id="protection-set-1" var="protection_variable" value="1" scope="player"/>
@@ -509,7 +407,7 @@ Features:
         <message text="`e`l▲ `6Your team now has permanent `e`lShears`r"/>
         <set var="shears_variable" value="1"/>
         <kit force="true" filter="always">
-            <item material="shears" unbreakable="true"/>
+            <item material="shears" enchantment="efficiency" unbreakable="true"/>
         </kit>
         <set var="upgrade_me_variable" value="1"/>
     </action>
@@ -731,6 +629,18 @@ Features:
         <set var="upgrade_me_variable" value="1"/>
     </action>
     <!-- Team upgrades: Blocks -->
+    <action id="water-bucket-action-1" scope="player">
+        <set var="water_bucket_variable" value="1"/>
+        <message text="`e`l▲ `6Team kit upgraded to `e`lWater Bucket`r"/>
+        <replace-item>
+            <find material="bucket"/>
+            <replace material="air"/>
+        </replace-item>
+        <kit force="true">
+            <item material="water bucket"/>
+        </kit>
+        <set var="upgrade_me_variable" value="1"/>
+    </action>
     <action id="block-boost-action-1" scope="player">
         <set var="block_boost_variable" value="1"/>
         <message text="`e`l▲ `6Team kit upgraded to `e`lBlock Boost I`r"/>
@@ -1131,12 +1041,12 @@ Features:
     <trigger filter="respawn-reset-phase-1-done" trigger="reset-stuff-part-2" scope="player"/>
     <action id="tnt-action" scope="player">
         <kit force="true" filter="always" deduct-items="false">
-            <item material="tnt" amount="2"/>
+            <item material="tnt" amount="1"/>
         </kit>
     </action>
     <action id="god-apple-action" scope="player">
         <kit force="true" filter="always" deduct-items="false">
-            <item material="golden_apple" damage="1" amount="3"/> <!-- yes, that one -->
+            <item material="golden_apple" damage="1" amount="2"/> <!-- yes, that one -->
         </kit>
     </action>
     <action id="knockback-apple-action" scope="player">
@@ -1258,6 +1168,16 @@ Features:
             </action>
             <item material="diamond sword" unbreakable="true" enchantment="sharpness:2"/>
         </kit>
+        <!-- Reset: Water Bucket Upgrade -->
+        <action filter="water-bucket-1">
+            <replace-item>
+                <find material="bucket"/>
+                <replace material="air"/>
+            </replace-item>
+            <kit force="true">
+                <item material="water bucket"/>
+            </kit>
+        </action>
         <!-- Reset: Block Boost 1 Upgrade -->
         <kit force="true" filter="block-boost-1" deduct-items="true">
             <item material="wood" amount="64"/>
@@ -1334,13 +1254,7 @@ Features:
 <variables>
     <variable id="reset_phase_variable" default="0" scope="player"/> <!-- 0=dead 1=phase1Done 2=phase2Done -->
     <!-- pickup redstone and emerald block variables for sounds and helmet upgrade -->
-    <variable id="pickup_green_momentary_variable" default="0" scope="player"/>
-    <variable id="pickup_red_momentary_variable" default="0" scope="player"/>
-    <variable id="pickup_them_variable" default="0" scope="player"/>
-    <variable id="pickup_me_variable" default="0" scope="player"/>
-    <variable id="pickup_theirs_variable" default="0" scope="player"/>
     <variable id="upgrade_me_variable" default="0" scope="player"/>
-    <variable id="pickup_enemy_count" default="0" scope="player"/>
     <!-- player vanity upgrade -->
     <variable id="vanity_hat_variable" default="0" scope="player"/>
     <variable id="vanity_chestplate_variable" default="0" scope="player"/>
@@ -1361,6 +1275,7 @@ Features:
     <variable id="protection_variable" default="0" scope="team"/>
     <variable id="sharpness_variable" default="0" scope="team"/>
     <variable id="block_boost_variable" default="0" scope="team"/>
+    <variable id="water_bucket_variable" default="0" scope="team"/>
 </variables>
 <filters>
     <team id="only-green">green-team</team>
@@ -1377,24 +1292,6 @@ Features:
     </any>
     <after id="respawn-reset-phase-1-done" duration="0.1s">
         <variable var="reset_phase_variable">1</variable>
-    </after>
-    <after id="pickup-green-momentary" duration="0.2s">
-        <variable var="pickup_green_momentary_variable">1</variable>
-    </after>
-    <after id="pickup-red-momentary" duration="0.2s">
-        <variable var="pickup_red_momentary_variable">1</variable>
-    </after>
-    <after id="redstone-pickup-warning" duration="5s">
-        <all>
-            <team>green-team</team>
-            <variable var="pickup_enemy_count">[14,oo)</variable>
-        </all>
-    </after>
-    <after id="emerald-pickup-warning" duration="5s">
-        <all>
-            <team>red-team</team>
-            <variable var="pickup_enemy_count">[14,oo)</variable>
-        </all>
     </after>
     <!-- Auto equip the diamond chestplate -->
     <all id="chestplate-holding">
@@ -1478,22 +1375,10 @@ Features:
             <item material="redstone block"/>
         </carrying>
     </all>
-    <all id="pickup-red2-filter-by-red"> <!-- Red picks up stolen redstone -->
-        <team>red-team</team>
-        <carrying ignore-metadata="false">
-            <item material="redstone block" name="Red Stolen block"/>
-        </carrying>
-    </all>
     <all id="pickup-green-filter-by-red"> <!-- Red picks up vanilla emerald -->
         <team>red-team</team>
         <carrying ignore-metadata="false">
             <item material="emerald block"/>
-        </carrying>
-    </all>
-    <all id="pickup-green2-filter-by-red"> <!-- Red picks up recovered emerald -->
-        <team>red-team</team>
-        <carrying ignore-metadata="false">
-            <item material="emerald block" name="Green Recovered block"/>
         </carrying>
     </all>
     <!-- Green Pick-up Filters -->
@@ -1503,76 +1388,35 @@ Features:
             <item material="emerald block"/>
         </carrying>
     </all>
-    <all id="pickup-green2-filter-by-green"> <!-- Green picks up stolen emerald -->
-        <team>green-team</team>
-        <carrying ignore-metadata="false">
-            <item material="emerald block" name="Green Stolen block"/>
-        </carrying>
-    </all>
     <all id="pickup-red-filter-by-green"> <!-- Green picks up vanilla redstone -->
         <team>green-team</team>
         <carrying ignore-metadata="false">
             <item material="redstone block"/>
         </carrying>
     </all>
-    <all id="pickup-red2-filter-by-green"> <!-- Green picks up recovered redstone -->
-        <team>green-team</team>
-        <carrying ignore-metadata="false">
-            <item material="redstone block" name="Red Recovered block"/>
-        </carrying>
-    </all>
-    <!-- More pickup related filters -->
-    <all id="red-pickup-red-filter">
-        <alive/>
-        <team>red-team</team>
-        <carrying>
-            <item material="redstone block"/>
-        </carrying>
-        <variable var="pickup_me_variable">0</variable>
-    </all>
-    <all id="red-pickup-green-filter">
-        <alive/>
-        <team>red-team</team>
-        <carrying>
-            <item material="emerald block"/>
-        </carrying>
-        <variable var="pickup_them_variable">0</variable>
-    </all>
-    <all id="green-pickup-red-filter">
-        <alive/>
-        <team>green-team</team>
-        <carrying>
-            <item material="redstone block"/>
-        </carrying>
-        <variable var="pickup_them_variable">0</variable>
-    </all>
-    <all id="green-pickup-green-filter">
-        <alive/>
-        <team>green-team</team>
-        <carrying>
-            <item material="emerald block"/>
-        </carrying>
-        <variable var="pickup_me_variable">0</variable>
-    </all>
     <!-- Vanity Diamond Helmet -->
     <any id="vanity-hat-filter">
         <all>
             <team>red-team</team>
             <variable var="vanity_hat_variable">0</variable>
-            <variable var="pickup_green_momentary_variable">1</variable>
             <any>
                 <region id="green-monument-1"/>
                 <region id="green-monument-2"/>
             </any>
+            <carrying ignore-metadata="true">
+                <item material="emerald block"/>
+            </carrying>
         </all>
         <all>
             <team>green-team</team>
             <variable var="vanity_hat_variable">0</variable>
-            <variable var="pickup_red_momentary_variable">1</variable>
             <any>
                 <region id="red-monument-1"/>
                 <region id="red-monument-2"/>
             </any>
+            <carrying ignore-metadata="true">
+                <item material="redstone block"/>
+            </carrying>
         </all>
     </any>
     <all id="helmet-replacement-filter">
@@ -1661,6 +1505,11 @@ Features:
     <variable id="gapple-king-0" var="gapple_king_variable">0</variable>
     <variable id="gapple-king-1" var="gapple_king_variable">1</variable>
     <variable id="block-boost-0" var="block_boost_variable">0</variable>
+    <variable id="water-bucket-0" var="water_bucket_variable">0</variable>
+    <all id="water-bucket-1">
+        <alive/>
+        <variable var="water_bucket_variable">1</variable>
+    </all>
     <all id="block-boost-1">
         <alive/>
         <variable var="block_boost_variable">1</variable>
@@ -1890,8 +1739,8 @@ Features:
         <!-- One-time Items -->
         <category id="player" name="`aItem Store" material="tnt">
             <item material="apple" name="`2Knockbapple II" enchantment="knockback:2" amount="1" price="5" currency="emerald block" color="dark green" action="knockback-apple-action" lore="`7One-time purchase:|`71 Knockbapple with Knockback II.|"/>
-            <item material="tnt" damage="1" name="`2TNT" amount="2" price="7" currency="emerald block" color="dark green" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
-            <item material="golden_apple" name="`2God Apples" damage="1" amount="3" price="24" currency="emerald block" color="dark green" action="god-apple-action" lore="`7One-time purchase:|`73 Enchanted Golden Apples.|"/>
+            <item material="tnt" damage="1" name="`2TNT" amount="1" price="6" currency="emerald block" color="dark green" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
+            <item material="golden_apple" name="`2God Apples" damage="1" amount="2" price="25" currency="emerald block" color="dark green" action="god-apple-action" lore="`7One-time purchase:|`72 Enchanted Golden Apples.|"/>
         </category>
     </shop>
     <!-- Shop - Team Upgrades -->
@@ -1900,6 +1749,7 @@ Features:
             <item material="shears" name="`4Permanent Shears" lore="`7Your team permanently gains|`7Shears for defense.|" unbreakable="true" price="1" currency="redstone block" filter="shears-0" action="shears-action" color="red"/>
             <item material="smooth brick" name="`4Block Boost I" amount="32" price="2" currency="redstone block" color="red" filter="block-boost-0" action="block-boost-action-1" lore="`7Your team permanently gains|`7Double number of blocks in kit.||`4Tier 1: Stack Size 32`7, `b2 Blocks|`7Tier 2: Stack Size 64, `b5 Blocks|"/>
             <item material="smooth brick" name="`4Block Boost II" amount="64" price="5" currency="redstone block" color="red" filter="block-boost-1" action="block-boost-action-2" lore="`7Your team permanently gains|`7Double number of blocks in kit, again.||`8Tier 1: Stack Size 32`7, `b2 Blocks|`4Tier 2: Stack Size 64`7, `b5 Blocks|"/>
+            <item material="water bucket" name="`4Water Bucket" price="4" currency="redstone block" color="red" filter="water-bucket-0" action="water-bucket-action-1" lore="`7Your team permanently gains|`7Water Bucket in kit.|"/>
             <item material="iron axe" name="`4Iron Axe and Shovel" filter="axe-shovel-0" action="axe-shovel-action-1" lore="`7Your team permanently gains|`7Iron Axe &#38; Shovel.||`4Tier 1: Iron Axe &#38; Shovel, `b3 Blocks|`7Tier 2: Diamond Axe &#38; Shovel, `b7 Blocks|`7Tier 3: Diamond Axe &#38; Shovel Efficiency I, `b30 Blocks|">
                 <payment price="3" currency="redstone block" color="red"/>
             </item>
@@ -1915,7 +1765,7 @@ Features:
             <item material="chainmail chestplate" amount="2" name="`4Reinforced Armor II" lore="`7Your team permanently gains|`7Protection II on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`4Tier 2: Protection II`7, `b25 Blocks|`7Tier 3: Protection III`7, `b30 Blocks|`7Tier 4: Protection IV`7, `b45 Blocks|" price="25" currency="redstone block" action="protection-set-2" filter="protection-1" color="red"/>
             <item material="gold chestplate" amount="3" name="`4Reinforced Armor III" lore="`7Your team permanently gains|`7Protection III on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`8Tier 2: Protection II`7, `b25 Blocks|`4Tier 3: Protection III`7, `b30 Blocks|`7Tier 4: Protection IV`7, `b45 Blocks|" price="30" currency="redstone block" action="protection-set-3" filter="protection-2" color="red"/>
             <item material="diamond chestplate" amount="4" name="`4Reinforced Armor IV" lore="`7Your team permanently gains|`7Protection IV on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`8Tier 2: Protection II`7, `b25 Blocks|`8Tier 3: Protection III`7, `b30 Blocks|`4Tier 4: Protection IV`7, `b45 Blocks|" price="45" currency="redstone block" action="protection-set-4" filter="protection-3" color="red"/>
-            <item material="iron helmet" name="`4Permanent Iron Helmet" lore="`7Your team permanently gains|`7Iron Helmet for kit.|" price="16" currency="redstone block" filter="iron-hat-0" action="iron-hat-action" color="red"/>
+            <item material="iron helmet" name="`4Permanent Iron Helmet" lore="`7Your team permanently gains|`7Iron Helmet for kit.|" price="12" currency="redstone block" filter="iron-hat-0" action="iron-hat-action" color="red"/>
             <item material="iron sword" name="`4Sharpened Swords" lore="`7Your team permanently gains|`7Sharpness I on all swords.||`4Tier 1: Sharpness I`7, `b20 Blocks|`7Tier 2: Sharpness II, `b50 Blocks|" price="20" currency="redstone block" action="sharpness-set-1" filter="sharpness-0" color="red"/>
             <item material="diamond sword" name="`4Sharpened Swords 2" lore="`7Your team permanently gains|`7Sharpness II on all swords.||`8Tier 1: Sharpness I`7, `b20 Blocks|`4Tier 2: Sharpness II, `b50 Blocks|" price="50" currency="redstone block" action="sharpness-set-2" filter="sharpness-1" color="red"/>
             <item material="beacon" name="`4Regen" lore="`7Creates a Regeneration field|`7around your monuments.|" price="30" currency="redstone block" action="regen-set" filter="regen-0" color="red"/>
@@ -1964,8 +1814,8 @@ Features:
         <!-- One-time Items -->
         <category id="player" name="`aItem Store" material="tnt">
             <item material="apple" name="`2Knockbapple II" enchantment="knockback:2" amount="1" price="5" currency="redstone block" color="red" action="knockback-apple-action" lore="`7One-time purchase:|`71 Knockbapple with Knockback II.|"/>
-            <item material="tnt" damage="1" name="`2TNT" amount="2" price="7" currency="redstone block" color="red" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
-            <item material="golden_apple" name="`2God Apples" damage="1" amount="3" price="24" currency="redstone block" color="red" action="god-apple-action" lore="`7One-time purchase:|`73 Enchanted Golden Apples.|"/>
+            <item material="tnt" damage="1" name="`2TNT" amount="1" price="6" currency="redstone block" color="red" action="tnt-action" lore="`7One-time purchase:|`71 Auto TNT.|"/>
+            <item material="golden_apple" name="`2God Apples" damage="1" amount="2" price="25" currency="redstone block" color="red" action="god-apple-action" lore="`7One-time purchase:|`72 Enchanted Golden Apples.|"/>
         </category>
     </shop>
     <!-- Shop - Team Upgrades -->
@@ -1974,6 +1824,7 @@ Features:
             <item material="shears" name="`2Permanent Shears" lore="`7Your team permanently gains|`7Shears for defense.|" unbreakable="true" price="1" currency="emerald block" filter="shears-0" action="shears-action" color="dark green"/>
             <item material="smooth brick" name="`2Block Boost I" amount="32" price="2" currency="emerald block" color="dark green" filter="block-boost-0" action="block-boost-action-1" lore="`7Your team permanently gains|`7Double number of blocks in kit.||`2Tier 1: Stack Size 32`7, `b2 Blocks|`7Tier 2: Stack Size 64, `b5 Blocks|"/>
             <item material="smooth brick" name="`2Block Boost II" amount="64" price="5" currency="emerald block" color="dark green" filter="block-boost-1" action="block-boost-action-2" lore="`7Your team permanently gains|`7Double number of blocks in kit, again.||`8Tier 1: Stack Size 32`7, `b2 Blocks|`2Tier 2: Stack Size 64`7, `b5 Blocks|"/>
+            <item material="water bucket" name="`2Water Bucket" price="4" currency="emerald block" color="dark green" filter="water-bucket-0" action="water-bucket-action-1" lore="`7Your team permanently gains|`7Water Bucket in kit.|"/>
             <item material="iron axe" name="`2Iron Axe and Shovel" filter="axe-shovel-0" action="axe-shovel-action-1" lore="`7Your team permanently gains|`7Iron Axe &#38; Shovel.||`2Tier 1: Iron Axe &#38; Shovel, `b3 Blocks|`7Tier 2: Diamond Axe &#38; Shovel, `b7 Blocks|`7Tier 3: Diamond Axe &#38; Shovel Efficiency I, `b30 Blocks|">
                 <payment price="3" currency="emerald block" color="dark green"/>
             </item>
@@ -1989,7 +1840,7 @@ Features:
             <item material="chainmail chestplate" amount="2" name="`2Reinforced Armor II" lore="`7Your team permanently gains|`7Protection II on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`2Tier 2: Protection II`7, `b25 Blocks|`7Tier 3: Protection III`7, `b30 Blocks|`7Tier 4: Protection IV`7, `b45 Blocks|" price="25" currency="emerald block" action="protection-set-2" filter="protection-1" color="dark green"/>
             <item material="gold chestplate" amount="3" name="`2Reinforced Armor III" lore="`7Your team permanently gains|`7Protection III on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`8Tier 2: Protection II`7, `b25 Blocks|`2Tier 3: Protection III`7, `b30 Blocks|`7Tier 4: Protection IV`7, `b45 Blocks|" price="30" currency="emerald block" action="protection-set-3" filter="protection-2" color="dark green"/>
             <item material="diamond chestplate" amount="4" name="`2Reinforced Armor IV" lore="`7Your team permanently gains|`7Protection IV on leggings/boots.||`8Tier 1: Protection I`7, `b12 Blocks|`8Tier 2: Protection II`7, `b25 Blocks|`8Tier 3: Protection III`7, `b30 Blocks|`2Tier 4: Protection IV`7, `b45 Blocks|" price="45" currency="emerald block" action="protection-set-4" filter="protection-3" color="dark green"/>
-            <item material="iron helmet" name="`2Permanent Iron Helmet" lore="`7Your team permanently gains|`7Iron Helmet for kit.|" price="16" currency="emerald block" filter="iron-hat-0" action="iron-hat-action" color="dark green"/>
+            <item material="iron helmet" name="`2Permanent Iron Helmet" lore="`7Your team permanently gains|`7Iron Helmet for kit.|" price="12" currency="emerald block" filter="iron-hat-0" action="iron-hat-action" color="dark green"/>
             <item material="iron sword" name="`2Sharpened Swords" lore="`7Your team permanently gains|`7Sharpness I on all swords.||`2Tier 1: Sharpness I`7, `b20 Blocks|`7Tier 2: Sharpness II, `b50 Blocks|" price="20" currency="emerald block" action="sharpness-set-1" filter="sharpness-0" color="dark green"/>
             <item material="diamond sword" name="`2Sharpened Swords 2" lore="`7Your team permanently gains|`7Sharpness II on all swords.||`8Tier 1: Sharpness I`7, `b20 Blocks|`2Tier 2: Sharpness II, `b50 Blocks|" price="50" currency="emerald block" action="sharpness-set-2" filter="sharpness-1" color="dark green"/>
             <item material="beacon" name="`2Regen" lore="`7Creates a Regeneration field|`7around your monuments.|" price="30" currency="emerald block" action="regen-set" filter="regen-0" color="dark green"/>
@@ -2025,17 +1876,17 @@ Features:
     </rule>
 </block-drops>
 <spawners player-region="everywhere">
-    <spawner spawn-region="green-monument-1" max-entities="4" delay="30s">
-        <item amount="2" material="emerald block"/>
+    <spawner spawn-region="green-monument-1" max-entities="5" delay="30s">
+        <item amount="3" material="emerald block"/>
     </spawner>
-    <spawner spawn-region="green-monument-2" max-entities="4" delay="30s">
-        <item amount="2" material="emerald block"/>
+    <spawner spawn-region="green-monument-2" max-entities="5" delay="30s">
+        <item amount="3" material="emerald block"/>
     </spawner>
-    <spawner spawn-region="red-monument-1" max-entities="4" delay="30s">
-        <item amount="2" material="redstone block"/>
+    <spawner spawn-region="red-monument-1" max-entities="5" delay="30s">
+        <item amount="3" material="redstone block"/>
     </spawner>
-    <spawner spawn-region="red-monument-2" max-entities="4" delay="30s">
-        <item amount="2" material="redstone block"/>
+    <spawner spawn-region="red-monument-2" max-entities="5" delay="30s">
+        <item amount="3" material="redstone block"/>
     </spawner>
 </spawners>
 <regions>
@@ -2054,7 +1905,7 @@ Features:
     </union>
     <negative id="not-build-area">
         <union id="build-area">
-            <cuboid min="-103,13,-63" max="104,65,64"/>
+            <cuboid min="-103,13,-63" max="104,75,64"/>
         </union>
     </negative>
     <cuboid id="red-monument-region" min="125,90,-22" max="130,116,20"/>
@@ -2099,6 +1950,7 @@ Features:
     <item>diamond spade</item>
     <item>shears</item>
     <item>bucket</item>
+    <item>water bucket</item>
     <!-- Armor -->
     <item>leather helmet</item>
     <item>leather chestplate</item>

--- a/dtcm/apple_smash/map.xml
+++ b/dtcm/apple_smash/map.xml
@@ -13,7 +13,7 @@ Features:
 - Auto-ignite TNT available as kill reward or purchase in the Player store
 -->
 <name>Apple Smash</name>
-<version>1.2.2</version>
+<version>1.2.3</version>
 <include id="gapple-kill-reward"/>
 <objective>Destroy the enemy's Apples!</objective>
 <gamemode>dtm</gamemode>


### PR DESCRIPTION
- Fix stacking of monument blocks, removing 150~ lines of nutty XML
- Add Team water bucket store option, other store tweaks
- Fixed annoying unremovable block area above build-limit
- Increase monument block spawner rate (for team upgrades)
- Broadcast tweaks