### PR TITLE
Bed Rush - Void Death Include, Kit Bug, etc

### DIFF
--- a/arcade/standard/bed_rush/map.xml
+++ b/arcade/standard/bed_rush/map.xml
@@ -1,7 +1,8 @@
 <map proto="1.4.2">
 <name>Bed Rush</name>
-<version>1.0.4</version>
+<version>1.0.5</version>
 <include id="gapple-kill-reward"/>
+<include id="void-death"/>
 <objective>Destroy the Bed to win the Round. First Team to 5 Wins!</objective>
 <created>2024-07-01</created>
 <authors>
@@ -34,7 +35,7 @@
 <!-- prefered gamemode is "bedrush" displayed as "Bed Rush" -->
 <gamemode>bridge</gamemode>
 <gamemode>bedwars</gamemode>
-<respawn auto="true" delay="0s"/>
+<respawn auto="true" delay="2s"/>
 <constants>
     <constant id="score-limit">5</constant>
     <constant id="red-team-spawn">0.5,21,-38.5</constant>
@@ -42,10 +43,12 @@
     <constant id="running">0</constant>
     <constant id="resetting">1</constant>
     <constant id="over">2</constant>
+    <constant id="void-plane">0</constant>
+    <constant id="health">1</constant>
 </constants>
 <broadcasts>
-    <alert after="1s" filter="red-only">`7`lDestroy the Blue Team's Bed!</alert>
-    <alert after="1s" filter="blue-only">`7`lDestroy the Red Team's Bed!</alert>
+    <alert after="1s" filter="red-only">`6`lRound `e1`7`l — Destroy the Blue Team's Bed!</alert>
+    <alert after="1s" filter="blue-only">`6`lRound `e1`7`l — Destroy the Red Team's Bed!</alert>
     <tip after="15s">`7`lThe map will reset after each round!</tip>
     <alert after="9m">`7If neither team wins 5 rounds the match will end in `c`l3 minutes`7!</alert>
 </broadcasts>
@@ -72,10 +75,6 @@
         <boots material="leather boots" enchantment="protection:3;feather_falling:1" team-color="true" unbreakable="true" locked="true"/>
         <health>20</health>
     </kit>
-    <kit id="void-death" force="true">
-        <clear effects="true" items="false" armor="false"/>
-        <health>1</health>
-    </kit>
     <give filter="all(resetting,alive)">
         <kit>
             <clear/>
@@ -85,6 +84,7 @@
         </kit>
     </give>
     <give filter="resetting-kit" kit="spawn-kit"/>
+    <give filter="naked" kit="spawn-kit"/>
 </kits>
 <damage>
     <deny>
@@ -97,7 +97,6 @@
 </damage>
 <filters>
     <alive id="alive"/>
-    <participating id="participating"/>
     <match-running id="match-running"/>
     <deny id="deny-red">
         <team id="red-only">red-team</team>
@@ -105,6 +104,17 @@
     <deny id="deny-blue">
         <team id="blue-only">blue-team</team>
     </deny>
+    <all id="naked">
+        <alive/>
+        <match-running/>
+        <variable var="round_state">${running}</variable>
+        <region id="above-void"/>
+        <not>
+            <wearing ignore-metadata="true">
+                <item material="leather helmet"/>
+            </wearing>
+        </not>
+    </all>
     <all id="resetting">
         <match-running/>
         <variable var="round_state">${resetting}</variable>
@@ -334,7 +344,7 @@
 </structures>
 <regions>
     <!-- course boundaries -->
-    <below id="void" y="0"/>
+    <above y="0" id="above-void"/>
     <above y="24" id="ceiling"/>
     <union id="no-go">
         <cuboid id="zone-1a" min="12,23,20" max="13,1,44"/>
@@ -371,7 +381,6 @@
     <apply block-place="never" region="bed-blue"/>
     <apply block-break="deny-red" region="bed-red" message="You may not break your own bed!"/>
     <apply block-break="deny-blue" region="bed-blue" message="You may not break your own bed!"/>
-    <apply kit="void-death" region="void"/>
 </regions>
 <portals sound="false" observers="never">
     <portal destination="red-team-spawn-point" forward="all(should-tp,alive)" filter="red-only" yaw="@0" pitch="@0"/>


### PR DESCRIPTION
Add void death include
Add respawn delay 2s
Give player kit when joining at other times than start of game or round
Use initial alert to mention "Round 1" in addition to objective.

