### PR TITLE
Fall of Babylon - Play test updates

### DIFF
--- a/ctw/standard/fall_of_babylon/map.xml
+++ b/ctw/standard/fall_of_babylon/map.xml
@@ -1,8 +1,8 @@
 <map proto="1.4.2">
 <name>Fall of Babylon</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <include id="gapple-kill-reward"/>
-<phase>development</phase>
+<phase>staging</phase>
 <gamemode>ctw</gamemode>
 <created>2024-10-01</created>
 <objective>Capture the wools</objective>
@@ -278,9 +278,7 @@
     </trigger>
     <!-- Wool seals - alerts entire match -->
     <action id="thunder-sounds" scope="match">
-        <sound key="ambient.weather.thunder" volume="1" pitch="1"/>
-        <sound key="ambient.weather.thunder" volume="1" pitch="0.9"/>
-        <sound key="ambient.weather.thunder" volume="1" pitch="0.8"/>
+        <sound key="ambient.weather.thunder" volume=".6" pitch="1"/>
     </action>
     <trigger filter="all(lime_seal_done=1,match-running)" scope="match">
         <action>
@@ -375,8 +373,6 @@
         <action>
             <switch-scope inner="match">
                 <fill region="blue-lime-light-power" material="redstone block" events="true"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="0.95"/>
             </switch-scope>
         </action>
     </trigger>
@@ -384,8 +380,6 @@
         <action>
             <switch-scope inner="match">
                 <fill region="blue-cyan-light-power" material="redstone block" events="true"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="0.95"/>
             </switch-scope>
         </action>
     </trigger>
@@ -393,8 +387,6 @@
         <action scope="player">
             <switch-scope inner="match">
                 <fill region="red-orange-light-power" material="redstone block" events="true"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
             </switch-scope>
         </action>
     </trigger>
@@ -402,8 +394,6 @@
         <action>
             <switch-scope inner="match">
                 <fill region="red-yellow-light-power" material="redstone block" events="true"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
-                <sound key="fireworks.twinkle_far" volume="1" pitch="1"/>
             </switch-scope>
         </action>
     </trigger>
@@ -411,8 +401,7 @@
     <action id="team-upgrade-sounds" scope="player">
         <sound preset="custom"/>
         <sound key="random.levelup" volume="0.8" pitch="0.8"/>
-        <sound key="fireworks.twinkle" volume="1" pitch="1"/>
-        <sound key="fireworks.twinkle" volume="1" pitch="0.9"/>
+        <sound key="fireworks.twinkle" volume="0.9" pitch="1"/>
     </action>
     <!-- Spy reports limited to Protection and Sharpness upgrades -->
     <action id="team-upgrade-armor-with-spy-report" scope="player">


### PR DESCRIPTION
Pear came on Sunday at request to test map, thanks Pear.  
Game play was too short to evaluate balance of currencies gold & diamonds, but functioned correctly as CTW.
There were some unexpected sounds towards the end of the match.   It is possible there was some conflict with game sounds and the PGM match complete sounds.  Based on this theory some sounds linked to objectives are removed.  Other sounds lowered in volume in response to one player's complaint that those sounds were too loud.
Pear wasn't sure about sign-off to Staging, but I included it here to facilitate testing if possible.  Thanks.

- Reduce volume of thunder for wool seals
- Remove firework twinkle sounds related to objective lamps
- Reduce firework twinkle sound related to team updates
- Staging mode