### PR TITLE
Near Sparks - Apple Smash, Cannonball Cove, Rock the Casbah

### DIFF
--- a/dtcm/apple_smash/map.xml
+++ b/dtcm/apple_smash/map.xml
@@ -13,7 +13,7 @@ Features:
 - Auto-ignite TNT available as kill reward or purchase in the Player store
 -->
 <name>Apple Smash</name>
-<version>1.2.3</version>
+<version>1.2.4</version>
 <include id="gapple-kill-reward"/>
 <objective>Destroy the enemy's Apples!</objective>
 <gamemode>dtm</gamemode>
@@ -1848,7 +1848,7 @@ Features:
         </category>
     </shop>
 </shops>
-<destroyables materials="emerald block;redstone block" mode-changes="false" sparks="false" repairable="false" show-progress="true" required="true" completion="95%">
+<destroyables materials="emerald block;redstone block" mode-changes="false" sparks="near" repairable="false" show-progress="true" required="true" completion="95%">
     <destroyable id="red-apple-1" name="Red Apple L" owner="red-team">
         <region><cuboid id="red-monument-1" min="-62,49,-29" max="-69,58,-22"/></region>
     </destroyable>

--- a/dtcm/cannonball_cove/map.xml
+++ b/dtcm/cannonball_cove/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Cannonball Cove</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
 <constant id="gapple-lore">Fer Cure o' Scurvy</constant>
 <include id="gapple-kill-reward"/>
 <objective>Destroy the core and flag - = - Rompe el núcleo y explota la bandera</objective>
@@ -114,7 +114,7 @@
 <crafting>
     <disable>flint and steel</disable> <!-- too op -->
 </crafting>
-<destroyables materials="wool;stained clay;ender stone;sea lantern" mode-changes="false" sparks="true" repairable="false" show-progress="true" required="true" completion="97%">
+<destroyables materials="wool;stained clay;ender stone;sea lantern" mode-changes="false" sparks="near" repairable="false" show-progress="true" required="true" completion="97%">
     <destroyable id="red-flag" name="Red Flag" owner="red-team">
         <region><cuboid id="red-monument" min="125,90,-22" max="129,116,20"/></region>
     </destroyable>

--- a/dtcm/rock_the_casbah/map.xml
+++ b/dtcm/rock_the_casbah/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Rock the Casbah</name>
-<version>1.2.2</version>
+<version>1.2.3</version>
 <include id="gapple-kill-reward"/>
 <include id="void-death"/>
 <objective>TNT the Pyramid!</objective>
@@ -101,7 +101,7 @@
         <material>tnt</material>
     </deny>
 </filters>
-<destroyables name="Pyramid" materials="ender stone" mode-changes="true" sparks="true" repairable="true" show-progress="true" required="true" completion="99%">
+<destroyables name="Pyramid" materials="ender stone" mode-changes="true" sparks="near" repairable="true" show-progress="true" required="true" completion="99%">
     <destroyable owner="blue-team">
         <region><cuboid id="blue-pyramid" min="70,79,-8" max="89,89,12"/></region>
     </destroyable>


### PR DESCRIPTION
These changes utilize the new PGM destroyable `sparks="near"` option (which is in PROD) that I developed with much help from Pablo, which disables the extra sparks sounds for monuments when players are more than 64 blocks away.

This keeps the sounds at a more manageable level and allows observers to "escape" the sounds.

- Apple Smash - going from zzuf updated value of "false" to "near"
- Cannonball Cove - going from "true" to "near"
- Rock the Casbah - going from "true" to "near"