### PR TITLE
Fall of Babylon - Play test updates

### DIFF
--- a/ctw/standard/fall_of_babylon/map.xml
+++ b/ctw/standard/fall_of_babylon/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.4.2">
 <name>Fall of Babylon</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <include id="gapple-kill-reward"/>
 <phase>staging</phase>
 <gamemode>ctw</gamemode>
@@ -65,6 +65,11 @@
             <effect>slow digging</effect>
         </kit>
     </lend>
+    <lend filter="store-forbidden-trigger">
+        <kit>
+            <effect amplifier="10">instant_damage</effect>
+        </kit>
+    </lend>
     <lend filter="blue-speed-boost">
         <kit>
             <effect>speed</effect>
@@ -85,10 +90,10 @@
             <effect amplifier="2">fast digging</effect>
         </kit>
     </give>
-    <give filter="all(strength_upgrade_variable=1,alive)">
+    <give filter="all(fireresist_upgrade_variable=1,alive)">
         <kit>
-            <item material="potion" damage="9">
-                <effect duration="45s">strength</effect>
+            <item material="potion" damage="3">
+                <effect duration="45s">fire resistance</effect>
             </item>
         </kit>
     </give>
@@ -280,55 +285,55 @@
     <action id="thunder-sounds" scope="match">
         <sound key="ambient.weather.thunder" volume=".6" pitch="1"/>
     </action>
-    <trigger filter="all(lime_seal_done=1,match-running)" scope="match">
-        <action>
-            <message text="`6⚡⚡⚡ `7`oThe `r`aLime Wool`r`7`l seal `r`7`ohas been broken!`r"/>
-            <action id="thunder-sounds"/>
-        </action>
-    </trigger>
     <trigger filter="all(lime-seal-broke,match-running)" scope="player">
         <action>
+            <set var="lime_seal_breaker" value="1"/>
             <switch-scope inner="match">
-                <set var="lime_seal_done" value="1"/>
+                <action id="thunder-sounds"/>
+                <message text="`6⚡⚡⚡ `7`oThe `r`aLime Wool`r`7`l seal `r`7`ohas been broken by {player}!`r">
+                    <replacements>
+                        <player id="player" var="lime_seal_breaker"/>
+                    </replacements>
+                </message>
             </switch-scope>
-        </action>
-    </trigger>
-    <trigger filter="all(cyan_seal_done=1,match-running)" scope="match">
-        <action>
-            <message text="`6⚡⚡⚡ `7`oThe `r`3Cyan Wool`r`7`l seal `r`7`ohas been broken!`r"/>
-            <action id="thunder-sounds"/>
         </action>
     </trigger>
     <trigger filter="all(cyan-seal-broke,match-running)" scope="player">
         <action>
+            <set var="cyan_seal_breaker" value="1"/>
             <switch-scope inner="match">
-                <set var="cyan_seal_done" value="1"/>
+                <action id="thunder-sounds"/>
+                <message text="`6⚡⚡⚡ `7`oThe `r`3Cyan Wool`r`7`l seal `r`7`ohas been broken by {player}!`r">
+                    <replacements>
+                        <player id="player" var="cyan_seal_breaker"/>
+                    </replacements>
+                </message>
             </switch-scope>
-        </action>
-    </trigger>
-    <trigger filter="all(yellow_seal_done=1,match-running)" scope="match">
-        <action>
-            <message text="`6⚡⚡⚡ `7`oThe `r`eYellow Wool`r`7`l seal `r`7`ohas been broken!`r"/>
-            <action id="thunder-sounds"/>
         </action>
     </trigger>
     <trigger filter="all(yellow-seal-broke,match-running)" scope="player">
         <action>
+            <set var="yellow_seal_breaker" value="1"/>
             <switch-scope inner="match">
-                <set var="yellow_seal_done" value="1"/>
+                <action id="thunder-sounds"/>
+                <message text="`6⚡⚡⚡ `7`oThe `r`eYellow Wool`r`7`l seal `r`7`ohas been broken by {player}!`r">
+                    <replacements>
+                        <player id="player" var="yellow_seal_breaker"/>
+                    </replacements>
+                </message>
             </switch-scope>
-        </action>
-    </trigger>
-    <trigger filter="all(orange_seal_done=1,match-running)" scope="match">
-        <action>
-            <message text="`6⚡⚡⚡ `7`oThe `r`6Orange Wool`r`7`l seal `r`7`ohas been broken!`r"/>
-            <action id="thunder-sounds"/>
         </action>
     </trigger>
     <trigger filter="all(orange-seal-broke,match-running)" scope="player">
         <action>
+            <set var="orange_seal_breaker" value="1"/>
             <switch-scope inner="match">
-                <set var="orange_seal_done" value="1"/>
+                <action id="thunder-sounds"/>
+                <message text="`6⚡⚡⚡ `7`oThe `r`6Orange Wool`r`7`l seal `r`7`ohas been broken by {player}!`r">
+                    <replacements>
+                        <player id="player" var="orange_seal_breaker"/>
+                    </replacements>
+                </message>
             </switch-scope>
         </action>
     </trigger>
@@ -399,9 +404,8 @@
     </trigger>
     <!-- Store Alerts -->
     <action id="team-upgrade-sounds" scope="player">
-        <sound preset="custom"/>
-        <sound key="random.levelup" volume="0.8" pitch="0.8"/>
-        <sound key="fireworks.twinkle" volume="0.9" pitch="1"/>
+        <sound key="random.levelup" volume="0.4" pitch="0.8"/>
+        <sound key="fireworks.twinkle" volume="0.4" pitch="1"/>
     </action>
     <!-- Spy reports limited to Protection and Sharpness upgrades -->
     <action id="team-upgrade-armor-with-spy-report" scope="player">
@@ -412,7 +416,7 @@
                 <sound key="fireworks.twinkle_far" volume="0.9" pitch="1"/>
                 <sound preset="objective_mode" volume="0.3" pitch="1.5"/>
                 <sound preset="custom" volume="0.5"/>
-                <message text="`4☠☠☠ `e`oSpys report that the enemy has upgraded armor!`r"/>
+                <message text="`4☠☠☠ `e`oSpies report that the enemy has upgraded armor!`r"/>
             </switch-scope>
         </switch-scope>
     </action>
@@ -424,7 +428,7 @@
                 <sound key="fireworks.twinkle_far" volume="0.9" pitch="1"/>
                 <sound preset="objective_mode" volume="0.3" pitch="1.5"/>
                 <sound preset="custom" volume="0.5"/>
-                <message text="`4☠☠☠ `e`oSpys report that the enemy has upgraded swords!`r"/>
+                <message text="`4☠☠☠ `e`oSpies report that the enemy has upgraded swords!`r"/>
             </switch-scope>
         </switch-scope>
     </action>
@@ -551,9 +555,9 @@
             <action id="team-upgrade-sounds"/>
         </action>
     </trigger>
-    <trigger filter="all(strength_upgrade_variable=1)" scope="player">
+    <trigger filter="all(fireresist_upgrade_variable=1)" scope="player">
         <action>
-            <message text="`4`l❥❥❥`e`l [`6`lTeam Upgrade`e`l] `b`lKit`2`l ➡ `f`lStrength Potion`r"/>
+            <message text="`4`l❥❥❥`e`l [`6`lTeam Upgrade`e`l] `b`lKit`2`l ➡ `f`lFire Resistance Potion`r"/>
             <action id="team-upgrade-sounds"/>
         </action>
     </trigger>
@@ -1915,7 +1919,7 @@
     <set id="feather-upgrade-3-set" var="feather_upgrade_variable" value="3" scope="player"/>
     <set id="haste-upgrade-1-set" var="haste_upgrade_variable" value="1" scope="player"/>
     <set id="haste-upgrade-2-set" var="haste_upgrade_variable" value="2" scope="player"/>
-    <set id="strength-upgrade-1-set" var="strength_upgrade_variable" value="1" scope="player"/>
+    <set id="fireresist-upgrade-1-set" var="fireresist_upgrade_variable" value="1" scope="player"/>
     <set id="blocks-upgrade-1-set" var="blocks_upgrade_variable" value="1" scope="player"/>
     <set id="bucket-upgrade-1-set" var="bucket_upgrade_variable" value="1" scope="player"/>
     <set id="speed-upgrade-1-set" var="speed_upgrade_variable" value="1" scope="player"/>
@@ -1932,6 +1936,10 @@
     <variable id="axe_upgrade_variable" scope="player"/>
     <variable id="shovel_upgrade_variable" scope="player"/>
     <variable id="hoe_upgrade_variable" scope="player"/>
+    <variable id="lime_seal_breaker" scope="player" exclusive="1"/>
+    <variable id="cyan_seal_breaker" scope="player" exclusive="1"/>
+    <variable id="yellow_seal_breaker" scope="player" exclusive="1"/>
+    <variable id="orange_seal_breaker" scope="player" exclusive="1"/>
     <!-- Team -->
     <variable id="blocks_upgrade_variable" scope="player"/>
     <variable id="bucket_upgrade_variable" scope="player"/>
@@ -1940,18 +1948,13 @@
     <variable id="ironsword_upgrade_variable" scope="team"/>
     <variable id="feather_upgrade_variable" scope="team"/>
     <variable id="haste_upgrade_variable" scope="team"/>
-    <variable id="strength_upgrade_variable" scope="team"/>
+    <variable id="fireresist_upgrade_variable" scope="team"/>
     <variable id="speed_upgrade_variable" scope="team"/>
     <variable id="fatigue_upgrade_variable" scope="team"/>
     <variable id="upgrading_team" scope="team" default="0" exclusive="1"/>
     <variable id="web_breaking_team" scope="team" default="0" exclusive="1"/>
     <variable id="webs_activated" scope="team" default="0" exclusive="1"/>
     <variable id="webs_to_be_activated" scope="team" default="0" exclusive="1"/>
-    <!-- Match -->
-    <variable id="lime_seal_done" scope="match" default="0"/>
-    <variable id="cyan_seal_done" scope="match" default="0"/>
-    <variable id="yellow_seal_done" scope="match" default="0"/>
-    <variable id="orange_seal_done" scope="match" default="0"/>
 </variables>
 <filters>
     <alive id="alive"/>
@@ -2003,6 +2006,10 @@
         </carrying>
         <completed>orange-wool</completed>
         <region id="near-yellow-region"/>
+    </all>
+    <all id="store-forbidden-trigger">
+        <alive/>
+        <region id="store-forbidden"/>
     </all>
     <all id="red-enemy-fatigue">
         <alive/>
@@ -2106,33 +2113,29 @@
             <material>air</material>
         </offset>
     </all>
-    <after id="lime-seal-broke" filter="lime-seal-broke-filter" duration="1s"/>
+    <after id="lime-seal-broke" filter="lime-seal-broke-filter" duration="0.5s"/>
     <all id="lime-seal-broke-filter">
         <offset vector="-119,61,134">
             <material>air</material>
         </offset>
-        <variable var="lime_seal_done">0</variable>
     </all>
-    <after id="cyan-seal-broke" filter="cyan-seal-broke-filter" duration="1s"/>
+    <after id="cyan-seal-broke" filter="cyan-seal-broke-filter" duration="0.5s"/>
     <all id="cyan-seal-broke-filter">
         <offset vector="119,61,134">
             <material>air</material>
         </offset>
-        <variable var="cyan_seal_done">0</variable>
     </all>
-    <after id="yellow-seal-broke" filter="yellow-seal-broke-filter" duration="1s"/>
+    <after id="yellow-seal-broke" filter="yellow-seal-broke-filter" duration="0.5s"/>
     <all id="yellow-seal-broke-filter">
         <offset vector="-119,61,-134">
             <material>air</material>
         </offset>
-        <variable var="yellow_seal_done">0</variable>
     </all>
-    <after id="orange-seal-broke" filter="orange-seal-broke-filter" duration="1s"/>
+    <after id="orange-seal-broke" filter="orange-seal-broke-filter" duration="0.5s"/>
     <all id="orange-seal-broke-filter">
         <offset vector="119,61,-134">
             <material>air</material>
         </offset>
-        <variable var="orange_seal_done">0</variable>
     </all>
     <!-- delay web breakable alerts to avoid too many things happening at once -->
     <after id="web-activate-red-filter" filter="red-webs-to-be-activated" duration="3s"/>
@@ -2247,13 +2250,13 @@
     <category id="player-diamond-upgrades" name="`aPermanent Kit Upgrades" material="diamond helmet">
         <item material="diamond helmet" name="`b`lDiamond Helmet" lore="`7You permanently gain|`7A Diamond Helmet|" price="5" currency="diamond" action="helmet-upgrade-1-set" filter="all(helmet_upgrade_variable=0)"/>
         <item material="diamond chestplate" name="`b`lDiamond Chestplate" lore="`7You permanently gain|`7A Diamond Chestplate|" price="10" currency="diamond" action="chestplate-upgrade-1-set" filter="all(chestplate_upgrade_variable=0)"/>
-        <item material="diamond leggings" name="`b`lDiamond Leggings" lore="`7You permanently gain|`7Diamond Leggings|" price="25" currency="diamond" action="leggings-upgrade-1-set" filter="all(leggings_upgrade_variable=0)"/>
-        <item material="diamond boots" name="`b`lDiamond Boots" lore="`7You permanently gain|`7Diamond Boots|" price="20" currency="diamond" action="boots-upgrade-1-set" filter="all(boots_upgrade_variable=0)"/>
-        <item material="diamond sword" name="`b`lDiamond Sword" lore="`7You permanently gain|`7A Diamond Sword|" price="10" currency="diamond" action="diamondsword-upgrade-1-set" filter="all(diamondsword_upgrade_variable=0)"/>
+        <item material="diamond leggings" name="`b`lDiamond Leggings" lore="`7You permanently gain|`7Diamond Leggings|" price="50" currency="diamond" action="leggings-upgrade-1-set" filter="all(leggings_upgrade_variable=0)"/>
+        <item material="diamond boots" name="`b`lDiamond Boots" lore="`7You permanently gain|`7Diamond Boots|" price="35" currency="diamond" action="boots-upgrade-1-set" filter="all(boots_upgrade_variable=0)"/>
+        <item material="diamond sword" name="`b`lDiamond Sword" lore="`7You permanently gain|`7A Diamond Sword|" price="15" currency="diamond" action="diamondsword-upgrade-1-set" filter="all(diamondsword_upgrade_variable=0)"/>
         <item material="diamond pickaxe" name="`b`lDiamond Pickaxe" lore="`7You permanently gain|`7A Diamond Pickaxe|" price="5" currency="diamond" action="pickaxe-upgrade-1-set" filter="all(pickaxe_upgrade_variable=0)"/>
         <item material="diamond axe" name="`b`lDiamond Axe" lore="`7You permanently gain|`7A Diamond Axe|" price="5" currency="diamond" action="axe-upgrade-1-set" filter="all(axe_upgrade_variable=0)"/>
-        <item material="diamond spade" enchantment="efficiency:1" name="`b`lDiamond Shovel" lore="`7You permanently gain|`7A Diamond Shovel|" price="2" currency="diamond" action="shovel-upgrade-1-set" filter="all(shovel_upgrade_variable=0)"/>
-        <item material="diamond hoe" name="`b`lDiamond Knockback Hoe" lore="`7You permanently gain|`7A Diamond Hoe with Knockback I|" price="15" currency="diamond" action="hoe-upgrade-1-set" filter="all(hoe_upgrade_variable=0)"/>
+        <item material="diamond spade" name="`b`lDiamond Shovel" lore="`7You permanently gain|`7A Diamond Shovel|" price="1" currency="diamond" action="shovel-upgrade-1-set" filter="all(shovel_upgrade_variable=0)"/>
+        <item material="diamond hoe" name="`b`lDiamond Knockback Hoe" lore="`7You permanently gain|`7A Diamond Hoe with Knockback I|" price="10" currency="diamond" action="hoe-upgrade-1-set" filter="all(hoe_upgrade_variable=0)"/>
     </category>
     <category id="player-diamond-purchase" name="`aDiamond Exchange" material="diamond block">
         <item material="flint and steel" name="`b`lFlint and Steel" lore="`7Purchase|`7Flint and Steel|" price="1" currency="diamond" kit="flint-and-steel"/>
@@ -2264,23 +2267,23 @@
 </shop>
 <shop id="team-upgrade-shop" name="Team Upgrades">
     <category id="team-upgrades" name="`6Upgrades for the Team" material="beacon" enchantment="protection">
-        <item material="iron helmet" enchantment="protection:1" name="`6`lProtection I (1 of 5)" lore="`7Your team permanently gains|`7Armor Protection I|`8`oLeggings and Boots|" price="70" currency="gold ingot" action="armor-upgrade-1-set" filter="armor_upgrade_variable=0"/>
-        <item material="iron helmet" enchantment="protection:2" name="`6`lProtection II (2 of 5)" lore="`7Your team permanently gains|`7Armor Protection II|`8`oLeggings and Boots|" price="80" currency="gold ingot" action="armor-upgrade-2-set" filter="armor_upgrade_variable=1"/>
-        <item material="iron helmet" enchantment="protection:3" name="`6`lProtection III (3 of 5)" lore="`7Your team permanently gains|`7Armor Protection III|`8`oLeggings and Boots|" price="90" currency="gold ingot" action="armor-upgrade-3-set" filter="armor_upgrade_variable=2"/>
-        <item material="iron helmet" enchantment="protection:4" name="`6`lProtection IV (4 of 5)" lore="`7Your team permanently gains|`7Armor Protection IV|`8`oLeggings and Boots|" price="100" currency="gold ingot" action="armor-upgrade-4-set" filter="armor_upgrade_variable=3"/>
-        <item material="iron helmet" enchantment="protection:5" name="`6`lProtection V (5 of 5)" lore="`7Your team permanently gains|`7Armor Protection V|`8`oLeggings and Boots|" price="125" currency="gold ingot" action="armor-upgrade-5-set" filter="armor_upgrade_variable=4"/>
-        <item material="stone sword" enchantment="sharpness:1" name="`6`lSharpness I (1 of 4)" lore="`7Your team permanently gains|`7Sharpness I Swords|" price="70" currency="gold ingot" action="sharp-upgrade-1-set" filter="sharp_upgrade_variable=0"/>
-        <item material="stone sword" enchantment="sharpness:2" name="`6`lSharpness II (2 of 4)" lore="`7Your team permanently gains|`7Sharpness II Swords|" price="90" currency="gold ingot" action="sharp-upgrade-2-set" filter="sharp_upgrade_variable=1"/>
-        <item material="stone sword" enchantment="sharpness:3" name="`6`lSharpness III (3 of 4)" lore="`7Your team permanently gains|`7Sharpness III Swords|" price="120" currency="gold ingot" action="sharp-upgrade-3-set" filter="sharp_upgrade_variable=2"/>
-        <item material="stone sword" enchantment="sharpness:4" name="`6`lSharpness IV (4 of 4)" lore="`7Your team permanently gains|`7Sharpness IV Swords|" price="150" currency="gold ingot" action="sharp-upgrade-4-set" filter="sharp_upgrade_variable=3"/>
+        <item material="iron helmet" enchantment="protection:1" name="`6`lProtection I (1 of 5)" lore="`7Your team permanently gains|`7Armor Protection I|`8`oLeggings and Boots|" price="80" currency="gold ingot" action="armor-upgrade-1-set" filter="armor_upgrade_variable=0"/>
+        <item material="iron helmet" enchantment="protection:2" name="`6`lProtection II (2 of 5)" lore="`7Your team permanently gains|`7Armor Protection II|`8`oLeggings and Boots|" price="100" currency="gold ingot" action="armor-upgrade-2-set" filter="armor_upgrade_variable=1"/>
+        <item material="iron helmet" enchantment="protection:3" name="`6`lProtection III (3 of 5)" lore="`7Your team permanently gains|`7Armor Protection III|`8`oLeggings and Boots|" price="120" currency="gold ingot" action="armor-upgrade-3-set" filter="armor_upgrade_variable=2"/>
+        <item material="iron helmet" enchantment="protection:4" name="`6`lProtection IV (4 of 5)" lore="`7Your team permanently gains|`7Armor Protection IV|`8`oLeggings and Boots|" price="150" currency="gold ingot" action="armor-upgrade-4-set" filter="armor_upgrade_variable=3"/>
+        <item material="iron helmet" enchantment="protection:5" name="`6`lProtection V (5 of 5)" lore="`7Your team permanently gains|`7Armor Protection V|`8`oLeggings and Boots|" price="200" currency="gold ingot" action="armor-upgrade-5-set" filter="armor_upgrade_variable=4"/>
+        <item material="stone sword" enchantment="sharpness:1" name="`6`lSharpness I (1 of 4)" lore="`7Your team permanently gains|`7Sharpness I Swords|" price="80" currency="gold ingot" action="sharp-upgrade-1-set" filter="sharp_upgrade_variable=0"/>
+        <item material="stone sword" enchantment="sharpness:2" name="`6`lSharpness II (2 of 4)" lore="`7Your team permanently gains|`7Sharpness II Swords|" price="100" currency="gold ingot" action="sharp-upgrade-2-set" filter="sharp_upgrade_variable=1"/>
+        <item material="stone sword" enchantment="sharpness:3" name="`6`lSharpness III (3 of 4)" lore="`7Your team permanently gains|`7Sharpness III Swords|" price="150" currency="gold ingot" action="sharp-upgrade-3-set" filter="sharp_upgrade_variable=2"/>
+        <item material="stone sword" enchantment="sharpness:4" name="`6`lSharpness IV (4 of 4)" lore="`7Your team permanently gains|`7Sharpness IV Swords|" price="200" currency="gold ingot" action="sharp-upgrade-4-set" filter="sharp_upgrade_variable=3"/>
         <item material="iron sword" name="`6`lIron Sword" lore="`7Your team permanently gains|`7Iron Swords|" price="50" currency="gold ingot" action="ironsword-upgrade-1-set" filter="ironsword_upgrade_variable=0"/>
         <item material="leather boots" enchantment="feather falling" name="`6`lFeather Falling I (1 of 3)" lore="`7Your team permanently gains|`7Feather Falling Boots|" price="40" currency="gold ingot" action="feather-upgrade-1-set" filter="feather_upgrade_variable=0"/>
         <item material="leather boots" enchantment="feather falling:2" name="`6`lFeather Falling II (2 of 3)" lore="`7Your team permanently gains|`7Feather Falling II Boots|" price="70" currency="gold ingot" action="feather-upgrade-2-set" filter="feather_upgrade_variable=1"/>
         <item material="leather boots" enchantment="feather falling:3" name="`6`lFeather Falling III (3 of 3)" lore="`7Your team permanently gains|`7Feather Falling III Boots|" price="100" currency="gold ingot" action="feather-upgrade-3-set" filter="feather_upgrade_variable=2"/>
         <item material="iron pickaxe" enchantment="efficiency" name="`6`lHaste I (1 of 2)" lore="`7Your team permanently gains|`7Haste I Effect|" price="60" currency="gold ingot" action="haste-upgrade-1-set" filter="haste_upgrade_variable=0"/>
-        <item material="iron pickaxe" enchantment="efficiency:2" name="`6`lHaste II (2 of 2)" lore="`7Your team permanently gains|`7Haste II Effect|" price="100" currency="gold ingot" action="haste-upgrade-2-set" filter="haste_upgrade_variable=1"/>
-        <item material="obsidian" name="`6`lMining Fatigue" lore="`7Your team permanently gains|`7Mining Fatigue Trap|`7Slow the Invaders at Home|" price="90" currency="gold ingot" action="fatigue-upgrade-1-set" filter="fatigue_upgrade_variable=0"/>
-        <item material="potion" damage="9" name="`6`lStrength I" lore="`7Your team permanently gains|`7Strength I Potion in Kit|`8`o45 seconds|" price="60" currency="gold ingot" action="strength-upgrade-1-set" filter="strength_upgrade_variable=0"/>
+        <item material="iron pickaxe" enchantment="efficiency:2" name="`6`lHaste II (2 of 2)" lore="`7Your team permanently gains|`7Haste II Effect|" price="120" currency="gold ingot" action="haste-upgrade-2-set" filter="haste_upgrade_variable=1"/>
+        <item material="obsidian" name="`6`lMining Fatigue" lore="`7Your team permanently gains|`7Mining Fatigue Trap|`7Slow the Invaders at Home|" price="100" currency="gold ingot" action="fatigue-upgrade-1-set" filter="fatigue_upgrade_variable=0"/>
+        <item material="potion" damage="3" name="`6`lFire Resistance I" lore="`7Your team permanently gains|`7Fire Resistance Potion in Kit|`8`o45 seconds|" price="40" currency="gold ingot" action="fireresist-upgrade-1-set" filter="fireresist_upgrade_variable=0"/>
         <item material="log" amount="64" damage="5" name="`6`lBlocks Upgrade" lore="`7Your team permanently gains|`7Additional Blocks in Kit|" price="40" currency="gold ingot" action="blocks-upgrade-1-set" filter="blocks_upgrade_variable=0"/>
         <item material="water bucket" name="`6`lWater Bucket" lore="`7Your team permanently gains|`7Water Bucket in Kit|" price="30" currency="gold ingot" action="bucket-upgrade-1-set" filter="bucket_upgrade_variable=0"/>
         <item material="potion" damage="2" name="`6`lSpeed I" lore="`7Your team permanently gains|`7Speed Effect at Home|" price="50" currency="gold ingot" action="speed-upgrade-1-set" filter="speed_upgrade_variable=0"/>
@@ -2416,6 +2419,12 @@
         <rectangle min="63,-121" max="28,-95"/> <!-- blue left -->
         <rectangle min="-62,-121" max="-27,-95"/> <!-- blue right -->
         <rectangle min="30,-130" max="-28,-113"/> <!-- blue center -->
+    </union>
+    <union id="store-forbidden">
+        <cuboid min="-10,63,-122" max="-13,67,-126"/> <!-- blue right -->
+        <cuboid min="11,63,-122" max="13,67,-126"/> <!-- blue left -->
+        <cuboid min="-10,63,122" max="-13,67,126"/> <!-- red left -->
+        <cuboid min="11,63,122" max="13,67,126"/> <!-- red right -->
     </union>
     <!-- applicators -->
     <apply block-break="only-spawn-seals" region="loot-seals"/>


### PR DESCRIPTION
- Team upgrade sounds have been reduced and lowered in volume, since some thought it was too loud
- Glitching into the shop keeper area now results in death to avoid blocking access to shop keepers
- Team upgrade for Strength potion nerfed down to Fire Resistance, price lowered, some thought too OP
- Team store prices boosted to slow progression a bit, especially upper tiers
- Diamond store prices boosted for leggings/boots such that full diamond armor costs 100 instead of 60 diamonds
- Seal actions reworked to include new PGM player name message replacement feature to show who broke the seal.
- Fixed spelling of spies