### PR TITLE
Wrath of Cthulhu - Minor Edit

### DIFF
--- a/ctw/wrath_of_cthulhu/map.xml
+++ b/ctw/wrath_of_cthulhu/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <include id="gapple-kill-reward"/>
 <name>Wrath of Cthulhu</name>
-<version>1.0.4</version>
+<version>1.0.5</version>
 <objective>Capture the two wools of the enemy team!</objective>
 <created>2024-11-02</created>
 <phase>staging</phase>
@@ -11,7 +11,7 @@
     <author uuid="d1c4b70c-e4df-4ed6-999a-2e959bdfdac7" contribution="Map Builder"/> <!-- HUDV -->
 </authors>
 <contributors>
-    <contributor uuid="430ec559-364a-4363-ac7a-2529050440ac" contribution="Map Feedback"/> <!-- mameBT -->
+    <contributor uuid="430ec559-364a-4363-ac7a-2529050440ac" contribution="Map Feedback/XML"/> <!-- mameBT -->
     <contributor uuid="c25a6f7b-4c42-40da-8cd6-add53f0c84eb" contribution="Map Feedback/XML"/> <!-- arcadeboss -->
     <contributor uuid="63ddf58a-ba2c-4d39-8481-6358bb46c63a" contribution="XML"/> <!-- samschaap -->
 </contributors>

--- a/ctw/wrath_of_cthulhu/map.xml
+++ b/ctw/wrath_of_cthulhu/map.xml
@@ -184,6 +184,7 @@
 </itemremove>
 <crafting>
     <disable>minecart</disable>
+    <disable>fishing rod</disable>
 </crafting>
 <itemkeep>
     <item>arrow</item>


### PR DESCRIPTION
This is a minor attribution edit for Cthulhu and disable of crafting fishing rods for Mish.

This is also a test of submitting an update directly to CommunityMaps/master.

Based on Pear's feedback in mapdev, if this was an edit for which I wanted feedback/confirmation I should leave the PR open with requested review.   Otherwise, I could hit the "Squash and merge" button.

Please let me know if that is correct or anything needs adjustment.  Thanks.