### PR TITLE
Bed Rush/Anubis - Show Final Bed Breaker

### DIFF
--- a/arcade/standard/bed_rush/map.xml
+++ b/arcade/standard/bed_rush/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.4.2">
 <name>Bed Rush</name>
 <game>Bed Rush</game>
-<version>1.0.7</version>
+<version>1.0.8</version>
 <include id="gapple-kill-reward"/>
 <include id="void-death"/>
 <objective>Destroy the Bed to win the Round. First Team to 5 Wins!</objective>
@@ -217,7 +217,15 @@
                     <player id="player" var="bed_breaker"/>
                 </replacements>
             </message>
-            <message text="`6`lThe Blue team won the round!"/>
+            <message text="`8`l╔═══════════════════════╗"/>
+            <message text="`r`9      Red Bed broken by `l{player}">
+                <replacements>
+                    <player id="player" var="bed_breaker"/>
+                </replacements>
+            </message>
+            <message text=""/>
+            <message text="`r`9          The Blue team won the round!"/>
+            <message text="`8`l╚═══════════════════════╝"/>
             <switch-scope inner="team" filter="blue-only">
                 <action id="bed-broke"/>
             </switch-scope>
@@ -232,7 +240,15 @@
                     <player id="player" var="bed_breaker"/>
                 </replacements>
             </message>
-            <message text="`6`lThe Red team won the round!"/>
+            <message text="`8`l╔═══════════════════════╗"/>
+            <message text="`r`c      Blue Bed broken by `l{player}">
+                <replacements>
+                    <player id="player" var="bed_breaker"/>
+                </replacements>
+            </message>
+            <message text=""/>
+            <message text="`r`c          The Red team won the round!"/>
+            <message text="`8`l╚═══════════════════════╝"/>
             <switch-scope inner="team" filter="red-only">
                 <action id="bed-broke"/>
             </switch-scope>
@@ -403,7 +419,7 @@
     <portal destination="red-team-spawn-point" forward="all(should-tp,alive)" filter="red-only" yaw="@0" pitch="@0"/>
     <portal destination="blue-team-spawn-point" forward="all(should-tp,alive)" filter="blue-only" yaw="@180" pitch="@0"/>
 </portals>
-<score>
+<score display="circle">
     <limit>${score-limit}</limit>
 </score>
 <itemremove>

--- a/arcade/standard/bed_rush_anubis/map.xml
+++ b/arcade/standard/bed_rush_anubis/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.4.2">
 <name>Bed Rush: Anubis</name>
 <game>Bed Rush</game>
-<version>1.0.4</version>
+<version>1.0.5</version>
 <include id="gapple-kill-reward"/>
 <include id="void-death"/>
 <objective>Destroy the Bed to win the Round. First Team to 5 Wins!</objective>
@@ -279,7 +279,15 @@
                     <player id="player" var="bed_breaker"/>
                 </replacements>
             </message>
-            <message text="`6`lThe Blue team won the round!"/>
+            <message text="`8`l╔═══════════════════════╗"/>
+            <message text="`r`9      Red Bed broken by `l{player}">
+                <replacements>
+                    <player id="player" var="bed_breaker"/>
+                </replacements>
+            </message>
+            <message text=""/>
+            <message text="`r`9          The Blue team won the round!"/>
+            <message text="`8`l╚═══════════════════════╝"/>
             <switch-scope inner="team" filter="blue-only">
                 <action id="bed-broke"/>
             </switch-scope>
@@ -294,7 +302,15 @@
                     <player id="player" var="bed_breaker"/>
                 </replacements>
             </message>
-            <message text="`6`lThe Red team won the round!"/>
+            <message text="`8`l╔═══════════════════════╗"/>
+            <message text="`r`c      Blue Bed broken by `l{player}">
+                <replacements>
+                    <player id="player" var="bed_breaker"/>
+                </replacements>
+            </message>
+            <message text=""/>
+            <message text="`r`c          The Red team won the round!"/>
+            <message text="`8`l╚═══════════════════════╝"/>
             <switch-scope inner="team" filter="red-only">
                 <action id="bed-broke"/>
             </switch-scope>
@@ -508,7 +524,7 @@
     <portal destination="red-team-spawn-point" forward="all(should-tp,alive)" filter="red-only" yaw="@270" pitch="@0"/>
     <portal destination="blue-team-spawn-point" forward="all(should-tp,alive)" filter="blue-only" yaw="@90" pitch="@0"/>
 </portals>
-<score>
+<score display="circle">
     <limit>${score-limit}</limit>
 </score>
 <itemkeep>


### PR DESCRIPTION
- Display a "card" in chat that displays the bed breaker
- This allows the final bed breaker to be announced, since big message gets skipped on last
- Use Pablo's new circle alternative score display mode