### PR TITLE
Bow Spleef: Shogun - Play test updates - Pulse

### DIFF
--- a/arcade/standard/bow_spleef_shogun/map.xml
+++ b/arcade/standard/bow_spleef_shogun/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.5.0" game="Bow Spleef">
 <name>Bow Spleef: Shogun</name>
-<version>1.0.1</version>
+<version>1.0.2</version>
 <phase>development</phase>
 <objective>Spleef your opponents with fire and be the last player alive!</objective>
 <gamemode>arcade</gamemode>
@@ -9,7 +9,7 @@
 <authors>
     <author uuid="c25a6f7b-4c42-40da-8cd6-add53f0c84eb"/> <!-- arcadeboss -->
 </authors>
-<players colors="true" max="45"/>
+<players colors="true" max="40"/>
 <world>
     <timeset>13000</timeset>
     <timelock>on</timelock>
@@ -19,7 +19,7 @@
         <clear/>
         <item slot="0" material="bow" unbreakable="true" enchantment="flame" name="`6Hama Yumi `4Fire Bow"/>
         <item slot="1" material="flint and steel" damage="20" name="`6Hiuchigama `4Fire Kit"/> <!-- about 45 uses -->
-        <item slot="2" projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball" amount="2"/>
+        <item slot="2" projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball" amount="1"/>
         <item slot="3" material="potion" damage="2" name="Ninja Speed (30s)">
             <effect duration="30s" amplifier="1">speed</effect>
         </item>
@@ -32,7 +32,7 @@
         <item slot="6" material="potion" damage="11" name="Ninja Jump (15s)">
             <effect duration="15" amplifier="6">jump_boost</effect>
         </item>
-        <item slot="8" amount="64" material="arrow"/>
+        <item slot="8" amount="4" material="arrow"/>
         <item slot="9" material="potion" damage="6">
              <effect duration="1200s">night_vision</effect>
         </item>
@@ -66,6 +66,22 @@
     <default yaw="180" region="obs-spawn-point"/>
 </spawns>
 <blitz/>
+<actions>
+    <trigger filter="arrow-pulse" scope="player">
+        <action>
+			<kit force="false" filter="always" deduct-items="true">
+				<item material="arrow" amount="4"/>
+			</kit>
+        </action>
+    </trigger>
+    <trigger filter="fireball-pulse" scope="player">
+        <action>
+			<kit force="false" filter="always" deduct-items="true">
+                <item projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball" amount="1"/>
+			</kit>
+        </action>
+    </trigger>
+</actions>
 <filters>
     <not id="not-carrying-bow">
         <carrying>
@@ -87,9 +103,15 @@
             <material>tnt</material>
         </not>
     </deny>
+    <pulse id="arrow-pulse" period="5s" duration="1s">
+        <match-running/>
+    </pulse>
+    <pulse id="fireball-pulse" period="60s" duration="1s">
+        <match-running/>
+    </pulse>
 </filters>
 <regions>
-    <cylinder id="obs-spawn-point" base="0,184,0" radius=".5" height="0"/>
+    <cylinder id="obs-spawn-point" base="0.5,184.1,0.5" radius=".5" height="0"/>
     <cylinder id="playable-area" base="0,145,0" radius="29" height="25"/>
     <above y="172" id="ceiling"/>
     <!-- applicators -->
@@ -98,13 +120,10 @@
     <apply block="original-block-protection-filter" message="You can't modify that block!"/>
 </regions>
 <spawners player-region="everywhere">
-    <spawner spawn-region="playable-area" max-entities="50" delay="1s">
-        <item amount="2" material="arrow"/>
-    </spawner>
-    <spawner spawn-region="playable-area" max-entities="8" delay="10s">
+    <spawner spawn-region="playable-area" max-entities="5" delay="10s">
         <item projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball"/>
     </spawner>
-    <spawner spawn-region="playable-area" max-entities="3" delay="30s">
+    <spawner spawn-region="playable-area" max-entities="5" delay="20s">
         <item material="flint and steel" damage="35" name="`6Hiuchigama `4Fire Kit"/> <!-- about 30 uses -->
     </spawner>
 </spawners>

--- a/arcade/standard/bow_spleef_shogun/map.xml
+++ b/arcade/standard/bow_spleef_shogun/map.xml
@@ -69,16 +69,16 @@
 <actions>
     <trigger filter="arrow-pulse" scope="player">
         <action>
-			<kit force="false" filter="always" deduct-items="true">
-				<item material="arrow" amount="4"/>
-			</kit>
+            <kit force="false" filter="always" deduct-items="true">
+                <item material="arrow" amount="4"/>
+            </kit>
         </action>
     </trigger>
     <trigger filter="fireball-pulse" scope="player">
         <action>
-			<kit force="false" filter="always" deduct-items="true">
+            <kit force="false" filter="always" deduct-items="true">
                 <item projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball" amount="1"/>
-			</kit>
+            </kit>
         </action>
     </trigger>
 </actions>


### PR DESCRIPTION
Main issue was players ran out of arrows towards end, so implemented Pablo's suggested pulse filter to effectively cool-down the bow to a standard rate, removed the arrow spawner drops.

Secondary issue was frame lag at beginning of match, to help slightly the kit Fireballs reduced to 1, and arrow supply gated.