### PR TITLE
Bow Spleef: Shogun - Quieter

### DIFF
--- a/arcade/standard/bow_spleef_shogun/map.xml
+++ b/arcade/standard/bow_spleef_shogun/map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <map proto="1.5.0" game="Bow Spleef">
 <name>Bow Spleef: Shogun</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
 <phase>development</phase>
 <objective>Spleef your opponents with fire and be the last player alive!</objective>
 <gamemode>arcade</gamemode>
@@ -91,8 +91,14 @@
             </kit>
         </action>
     </trigger>
+    <trigger filter="tnt-pulse" scope="match">
+        <action>
+            <kill-entities filter="tnt-primed"/>
+        </action>
+    </trigger>
 </actions>
 <filters>
+    <entity id="tnt-primed">primed tnt</entity>
     <not id="not-carrying-bow">
         <carrying>
             <item material="bow"/>
@@ -125,6 +131,7 @@
     <pulse id="fireball-pulse" period="60s" duration="1s">
         <match-running/>
     </pulse>
+    <pulse id="tnt-pulse" period="3s" duration="1s" filter="always"/>
 </filters>
 <regions>
     <cylinder id="obs-spawn-point" base="0.5,184.1,0.5" radius=".5" height="0"/>
@@ -140,7 +147,7 @@
     <apply block="original-block-protection-filter" message="You can't modify that block!"/>
 </regions>
 <spawners player-region="everywhere">
-    <spawner spawn-region="playable-area" max-entities="5" delay="10s">
+    <spawner spawn-region="playable-area" max-entities="10" delay="10s">
         <item projectile="throwable-fireball" material="fireball" name="`6Hadouken `4Fireball"/>
     </spawner>
     <spawner spawn-region="playable-area" max-entities="5" delay="20s">
@@ -151,7 +158,7 @@
     <projectile id="throwable-fireball" name="Fireball" projectile="Fireball" velocity=".5" click="right" power="1.2" damage="0" cooldown="2.5s"/>
 </projectiles>
 <tnt>
-    <fuse>1.2</fuse>
+    <fuse>4.0</fuse>
     <power>0</power>
     <blockdamage>false</blockdamage>
 </tnt>


### PR DESCRIPTION
- Update to make the game less noisy by removing TNT before they explode,  This doesn't affect game mechanics.
- h/t PeakDominance
