### PR TITLE
Fix team upgrades not applying to late joiners

### DIFF
--- a/ctw/mame_i_shrunk_the_pvpers/map.xml
+++ b/ctw/mame_i_shrunk_the_pvpers/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <name>Mame, I Shrunk the PvPers</name>
 <variant id="halloween" world="halloween" override="true">Mame, I Shrunk the Goblins</variant>
-<version>1.2.6</version>
+<version>1.2.7</version>
 <include id="gapple-kill-reward"/>
 <objective>Capture both of the enemy's wools, and buy upgrades from the villagers to help you do so!</objective>
 <if variant="default">
@@ -93,17 +93,17 @@
         </if>
     </kit>
     <!-- Upgrades -->
-    <give filter="haste=1">
+    <give filter="all(alive,haste=1)">
         <kit>
             <effect>fast digging</effect>
         </kit>
     </give>
-    <give filter="haste=2">
+    <give filter="all(alive,haste=2)">
         <kit>
             <effect amplifier="2">fast digging</effect>
         </kit>
     </give>
-    <give filter="speed=1">
+    <give filter="all(alive,speed=1)">
         <kit>
             <effect>speed</effect>
         </kit>
@@ -310,12 +310,12 @@
     <trigger filter="upgraded-pick" trigger="stonepickdelete" scope="player"/>
     <trigger filter="upgraded-axe" trigger="stoneaxedelete" scope="player"/>
     <trigger filter="upgraded-spade" trigger="stonespadedelete" scope="player"/>
-    <trigger filter="sharpness=1" trigger="sharpness-replacements" scope="player"/>
-    <trigger filter="protection=1" trigger="protection-replacements" scope="player"/>
+    <trigger filter="all(alive,sharpness=1)" trigger="sharpness-replacements" scope="player"/>
+    <trigger filter="all(alive,protection=1)" trigger="protection-replacements" scope="player"/>
     <!-- Armor triggers -->
-    <trigger filter="armor=1" trigger="chainmail-teamreplace" scope="player"/>
-    <trigger filter="armor=2" trigger="iron-teamreplace" scope="player"/>
-    <trigger filter="armor=3" trigger="diamond-teamreplace" scope="player"/>
+    <trigger filter="all(alive,armor=1)" trigger="chainmail-teamreplace" scope="player"/>
+    <trigger filter="all(alive,armor=2)" trigger="iron-teamreplace" scope="player"/>
+    <trigger filter="all(alive,armor=3)" trigger="diamond-teamreplace" scope="player"/>
     <!-- Nugget rewards -->
     <trigger scope="match">
         <filter>


### PR DESCRIPTION
makes sure dying-then-reviving re-applies the team upgrade effects