### PR TITLE
Estimate created date for maps missing a date

### DIFF
--- a/5cp/backstreets/map.xml
+++ b/5cp/backstreets/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Backstreets</name>
 <version>1.2</version>
+<created>2024-12-22</created><!--created date derived from commit 6fcc818f-->
 <variant id="5v5">5v5</variant>
 <objective>Capture all five control points.</objective>
 <constant id="team-1-name">Blue</constant>

--- a/arcade/infection/infection_amusement_park/map.xml
+++ b/arcade/infection/infection_amusement_park/map.xml
@@ -2,6 +2,7 @@
 <name>Infection: Amusement Park</name>
 <variant id="halloween" world="halloween">Halloween Edition</variant>
 <version>1.1.4</version>
+<created>2022-04-12</created><!--created date derived from commit 0a44b860-->
 <include id="infection"/>
 <if variant="default">
     <created>2022-04-01</created>

--- a/arcade/infection/infection_boulevard/map.xml
+++ b/arcade/infection/infection_boulevard/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Infection: Boulevard</name>
 <version>1.0.7</version>
+<created>2022-08-03</created><!--created date derived from commit 52bf6121-->
 <include id="infection"/>
 <authors>
     <author uuid="74948888-fdb8-4446-9340-f7688c2435cc"/> <!-- Zero_Frosty -->

--- a/arcade/infection/infection_cinema_jungle_scenario/map.xml
+++ b/arcade/infection/infection_cinema_jungle_scenario/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Infection: Cinema Jungle Scenario</name>
 <version>1.2.6</version>
+<created>2022-10-04</created><!--created date derived from commit 792d3711-->
 <phase>staging</phase>
 <include id="infection"/>
 <constants>

--- a/arcade/kings_conquest/kings_conquest_rage_quit/map.xml
+++ b/arcade/kings_conquest/kings_conquest_rage_quit/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>King's Conquest: Rage Quit</name>
 <version>1.1.2</version>
+<created>2023-08-23</created><!--created date derived from commit 4a3b3121-->
 <constants>
     <constant id="team-one-spawn-a">-43.5,9,44.5</constant>
     <constant id="team-one-yaw-a">135</constant>

--- a/arcade/standard/blackblack_reborn/map.xml
+++ b/arcade/standard/blackblack_reborn/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>BlackBlack Reborn</name>
 <version>1.0.1</version>
+<created>2023-10-19</created><!--created date derived from commit 99a2d288-->
 <objective>Eliminate all enemies or capture the Wool!</objective>
 <authors>
     <author uuid="b1521072-6993-4fe4-ae60-dbeeb7dc0cfa"/> <!-- Antnecb -->

--- a/arcade/standard/cacti_mayhem_overdrive/map.xml
+++ b/arcade/standard/cacti_mayhem_overdrive/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Cacti Mayhem Overdrive</name>
 <version>1.2.13</version>
+<created>2023-12-10</created><!--created date derived from commit 4c517fb3-->
 <phase>staging</phase>
 <objective>Be the last man standing!</objective>
 <authors>

--- a/arcade/standard/dodge_ball_stadium/map.xml
+++ b/arcade/standard/dodge_ball_stadium/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Dodge Ball Stadium</name>
 <version>1.0.0</version>
+<created>2022-10-03</created><!--created date derived from commit 8a111d15-->
 <phase>staging</phase>
 <objective>Kill the other team.</objective>
 <gamemode>br</gamemode>

--- a/arcade/standard/freeze_tag_snowy_frontier/map.xml
+++ b/arcade/standard/freeze_tag_snowy_frontier/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Freeze Tag: Snowy Frontier</name>
 <version>1.0.1</version>
+<created>2024-08-23</created><!--created date derived from commit cc2712b4-->
 <include id="freeze-tag"/>
 <authors>
     <author uuid="f690a591-348b-482e-a18d-7779d0c0a28c" /> <!-- mitchiii_ -->

--- a/arcade/standard/grinch_s_heist_of_st_carrotfields/map.xml
+++ b/arcade/standard/grinch_s_heist_of_st_carrotfields/map.xml
@@ -2,6 +2,7 @@
 <name>The Grinch's Heist of St. Carrotfields</name>
 <slug>grinch_s_heist_of_st_carrotfields</slug>
 <version>1.0.4</version>
+<created>2023-12-03</created><!--created date derived from commit e3c955e4-->
 <objective>Stop the Grinch from stealing the presents!</objective>
 <gamemode>arcade</gamemode>
 <gamemode>scorebox</gamemode>

--- a/arcade/standard/hide_n_seek/map.xml
+++ b/arcade/standard/hide_n_seek/map.xml
@@ -2,6 +2,7 @@
 <name>Hide n' Seek</name>
 <phase>staging</phase>
 <version>2.1.7</version>
+<created>2022-01-20</created><!--created date derived from commit 9161caa9-->
 <objective>Find all the hiders before the 7 minutes are up!</objective>
 <gamemode>arcade</gamemode>
 <variant id="community" world="community">Community</variant>

--- a/arcade/standard/mega_cacti_mania/map.xml
+++ b/arcade/standard/mega_cacti_mania/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Mega Cacti Mania</name>
 <version>1.2.2</version>
+<created>2022-09-11</created><!--created date derived from commit 33a54060-->
 <objective>Eliminate the other players before the time is up.</objective>
 <authors>
     <author uuid="dd8c3d79-3930-41f6-a815-621dc3d52649"/> <!-- StanleyTheCow -->

--- a/arcade/standard/mobarena_silent_city/map.xml
+++ b/arcade/standard/mobarena_silent_city/map.xml
@@ -2,6 +2,7 @@
 <name>MobArena: Silent City</name>
 <phase>staging</phase>
 <version>1.3.2</version>
+<created>2022-07-13</created><!--created date derived from commit 90e5a83c-->
 <gamemode>arcade</gamemode>
 <objective>Defend yourself against hostile mobs for as long you can!</objective>
 <authors>

--- a/arcade/standard/place_the_wool/map.xml
+++ b/arcade/standard/place_the_wool/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Place the Wool</name>
 <version>1.0.1</version>
+<created>2025-01-07</created><!--created date derived from commit 1ace1d90-->
 <phase>staging</phase>
 <objective>Find the right pedestal for your wool</objective>
 <authors>

--- a/arcade/standard/skynet/map.xml
+++ b/arcade/standard/skynet/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Skynet</name>
 <version>1.0.3</version>
+<created>2023-05-05</created><!--created date derived from commit a6afee97-->
 <objective>Use the skynet to dominate the hills!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/arcade/standard/the_beast_incarnate/map.xml
+++ b/arcade/standard/the_beast_incarnate/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0" game="Infection">
 <name>The Beast Incarnate</name>
 <version>1.2.5</version>
+<created>2023-09-30</created><!--created date derived from commit f28bb1b7-->
 <objective>Kill the beast to become the new BEAST.</objective>
 <phase>staging</phase>
 <gamemode>arcade</gamemode>

--- a/arcade/standard/the_grand_dueling_tournament_ii/map.xml
+++ b/arcade/standard/the_grand_dueling_tournament_ii/map.xml
@@ -10,6 +10,7 @@
 -->
 <name>The Grand Dueling Tournament II</name>
 <version>2.9.0</version>
+<created>2021-11-17</created><!--created date derived from commit 467ce27b-->
 <objective>Defeat opposing teams in The Grand ${tournament-type} Tournament!</objective>
 <phase>staging</phase>
 <variant id="spleef" world="spleef" override="true">The Grand Spleefing Tournament II</variant>

--- a/arcade/standard/tnt_tag_block_fortress/map.xml
+++ b/arcade/standard/tnt_tag_block_fortress/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>TNT Tag: Block Fortress</name>
 <version>1.2.1</version>
+<created>2024-06-30</created><!--created date derived from commit 0e500066-->
 <include id="tnt-tag"/>
 <authors>
     <author uuid="2a289d2a-d970-49c5-9a6c-01fc0264e317"/> <!-- Stealth5061 -->

--- a/arcade/standard/tnt_tag_zoo/map.xml
+++ b/arcade/standard/tnt_tag_zoo/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>TNT Tag: Zoo</name>
 <version>1.0.2</version>
+<created>2024-08-22</created><!--created date derived from commit 0e8c9930-->
 <include id="tnt-tag"/>
 <authors>
     <author uuid="2fa85349-2276-4850-b7b5-d18c4f4c8376"/> <!-- Solo_Runner -->

--- a/arcade/standard/turf_warz/map.xml
+++ b/arcade/standard/turf_warz/map.xml
@@ -2,6 +2,7 @@
 <name>Turf Warz</name>
 <variant id="christmas" world="christmas">Christmas</variant>
 <version>1.0.6</version>
+<created>2024-12-22</created><!--created date derived from commit dd1cea84-->
 <phase>development</phase>
 <objective>Tug of war with your opponents as kills increase your playable territory.</objective>
 <authors>

--- a/arcade/standard/water_drop_cacti_terror/map.xml
+++ b/arcade/standard/water_drop_cacti_terror/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0" game="Water Drop">
 <name>Water Drop: Cacti Terror</name>
 <version>2.0.4</version>
+<created>2022-03-27</created><!--created date derived from commit 1d7cfaf0-->
 <objective>Get to the bottom 4 times!</objective>
 <gamemode>arcade</gamemode>
 <include id="void-death"/>

--- a/arcade/standard/water_drop_directrix/map.xml
+++ b/arcade/standard/water_drop_directrix/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0" game="Water Drop">
 <name>Water Drop: Directrix</name>
 <version>2.0.3</version>
+<created>2022-03-27</created><!--created date derived from commit 8638da22-->
 <objective>Reach the end 2 times!</objective>
 <gamemode>arcade</gamemode>
 <include id="void-death"/>

--- a/arcade/standard/water_drop_disc_wars/map.xml
+++ b/arcade/standard/water_drop_disc_wars/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0" game="Water Drop">
 <name>Water Drop: Disc Wars</name>
 <version>1.0.2</version>
+<created>2024-04-09</created><!--created date derived from commit bf8d81f6-->
 <objective>Reach the end 2 times!</objective>
 <include id="void-death"/>
 <constants>

--- a/blitz/cannon_duel_diagonal/map.xml
+++ b/blitz/cannon_duel_diagonal/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Cannon Duel: Diagonal</name>
 <version>1.0.3</version>
+<created>2023-06-27</created><!--created date derived from commit 9d6eb68a-->
 <objective>Kill them before they kill you!</objective>
 <gamemode>blitz</gamemode>
 <phase>staging</phase>

--- a/blitz/cornucopia/map.xml
+++ b/blitz/cornucopia/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Cornucopia</name>
 <version>1.0.1</version>
+<created>2023-11-13</created><!--created date derived from commit c24cfe50-->
 <objective>Eliminate the other team before the time is up!</objective>
 <gamemode>blitz</gamemode>
 <authors>

--- a/bridge/over_troubled_water/map.xml
+++ b/bridge/over_troubled_water/map.xml
@@ -2,6 +2,7 @@
 <name>Over Troubled Water</name>
 <variant id="halloween" world="halloween" override="true">Over Twisted Water</variant>
 <version>1.0.9</version>
+<created>2023-04-07</created><!--created date derived from commit 2a3645d5-->
 <objective>Jump into the enemy team's portal, located behind their spawn point!</objective>
 <unless variant="halloween">
     <created>2023-04-05</created>

--- a/bridge/rockaway_bridge/map.xml
+++ b/bridge/rockaway_bridge/map.xml
@@ -2,6 +2,7 @@
 <name>Rockaway Bridge</name>
 <variant id="halloween" override="true">Rockaway Ridge</variant>
 <version>1.0.9</version>
+<created>2023-04-30</created><!--created date derived from commit 0744abb4-->
 <objective>Jump into the enemy team's portal, located behind their spawn point!</objective>
 <unless variant="halloween">
     <created>2023-04-29</created>

--- a/ctf/cathedral_football/map.xml
+++ b/ctf/cathedral_football/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Cathedral Football</name>
 <version>2.5.2</version>
+<created>2023-08-11</created><!--created date derived from commit 7597cad3-->
 <objective>Capture the flag as many times as possible in ten minutes!</objective>
 <gamemode>ffb</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctf/cherno_ctf/map.xml
+++ b/ctf/cherno_ctf/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Cherno CTF</name>
 <version>1.1.1</version>
+<created>2022-08-04</created><!--created date derived from commit 69c4e119-->
 <objective>Capture the enemy flag.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctf/flag_football_ice_rift/map.xml
+++ b/ctf/flag_football_ice_rift/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Ice Rift</name>
 <version>1.0.1</version>
+<created>2022-10-30</created><!--created date derived from commit f382cb07-->
 <slug>flag_football_ice_rift</slug>
 <constants>
     <constant id="team-1-spawn-yaw">0</constant>

--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Pipes and Punters</name>
 <version>1.5</version>
+<created>2022-07-16</created><!--created date derived from commit 5fd316e6-->
 <variant id="christmas" world="christmas" override="true">Penguins and Punters</variant>
 <variant id="halloween" world="halloween" override="true">Boo Pipes</variant>
 <objective>Score the flag in the enemy's pipe as many times as possible!</objective>

--- a/ctf/quidditch/map.xml
+++ b/ctf/quidditch/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Quidditch</name>
 <version>1.0.2</version>
+<created>2023-05-01</created><!--created date derived from commit 43fcc31e-->
 <objective>Capture the flag by passing through an enemy ring!</objective>
 <include id="gapple-kill-reward"/>
 <phase>staging</phase>

--- a/ctf/totem_crusaders/map.xml
+++ b/ctf/totem_crusaders/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Totem Crusaders</name>
 <version>1.2.1</version>
+<created>2022-08-09</created><!--created date derived from commit ea5c2637-->
 <objective>Take the flag to the end of the path back to your spawn!</objective>
 <phase>staging</phase>
 <authors>

--- a/ctf/tuscany_hills/map.xml
+++ b/ctf/tuscany_hills/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Tuscany Hills</name>
 <version>1.0.9</version>
+<created>2022-10-14</created><!--created date derived from commit 67ae93a6-->
 <objective>Capture the enemy's flag 3 times to win!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctw/acapulco/map.xml
+++ b/ctw/acapulco/map.xml
@@ -2,6 +2,7 @@
 <name>Acapulco</name>
 <variant id="halloween" world="halloween" override="true">Acapumpkin</variant>
 <version>1.0.7</version>
+<created>2023-07-17</created><!--created date derived from commit 80ee98a9-->
 <objective>Capture the wool!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/constellation/map.xml
+++ b/ctw/constellation/map.xml
@@ -2,6 +2,7 @@
 <name>Constellation</name>
 <variant id="christmas" world="christmas" override="true">Coldstellation</variant>
 <version>1.0.4</version>
+<created>2024-07-28</created><!--created date derived from commit 1daacb5e-->
 <objective>Capture the enemy team's wool!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/daydream_mini/map.xml
+++ b/ctw/daydream_mini/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Daydream Mini</name>
 <version>1.1.3</version>
+<created>2022-12-04</created><!--created date derived from commit 752334c7-->
 <variant id="christmas" world="christmas" override="true">Chillside Mini</variant>
 <objective>Capture each wool from the enemy teams!</objective>
 <if variant="default">

--- a/ctw/dead_noon/map.xml
+++ b/ctw/dead_noon/map.xml
@@ -2,6 +2,7 @@
 <name>Dead Noon</name>
 <variant id="halloween" world="halloween" override="true">Undead Noon</variant>
 <version>1.2.1</version>
+<created>2022-08-08</created><!--created date derived from commit 66df9c25-->
 <objective>Capture the wool!</objective>
 <include id="gapple-kill-reward"/>
 <if variant="default">

--- a/ctw/deciduous_nights/map.xml
+++ b/ctw/deciduous_nights/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Deciduous Nights</name>
 <version>1.2.2</version>
+<created>2022-07-16</created><!--created date derived from commit 28649bc9-->
 <variant id="christmas" world="christmas" override="true">Silent Nights</variant>
 <variant id="halloween" world="halloween" override="true">Deciduous Frights</variant>
 <objective>Capture the enemy team's wool!</objective>

--- a/ctw/duality/map.xml
+++ b/ctw/duality/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Duality</name>
 <version>1.1.3</version>
+<created>2022-01-08</created><!--created date derived from commit 982bd04f-->
 <variant id="halloween" world="halloween" override="true">SpOOkality</variant>
 <include id="gapple-kill-reward"/>
 <objective>Capture both enemy wools!</objective>

--- a/ctw/enchanted/map.xml
+++ b/ctw/enchanted/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Enchanted</name>
 <version>1.7.7</version>
+<created>2020-08-22</created><!--created date derived from commit de0664f4-->
 <include id="gapple-kill-reward"/>
 <variant id="halloween" world="halloween" override="true">Bewitched</variant>
 <variant id="christmas" world="christmas">Christmas</variant>

--- a/ctw/flush_vibes_ii/map.xml
+++ b/ctw/flush_vibes_ii/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0"> <!-- built in April 2019 -->
 <name>Flush Vibes II</name>
 <version>1.0.4</version>
+<created>2022-03-17</created><!--created date derived from commit 84c119b6-->
 <objective>Capture the wool!</objective>
 <include id="gapple-kill-reward"/>
 <gamemode>ctw</gamemode>

--- a/ctw/gethsemane/map.xml
+++ b/ctw/gethsemane/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Gethsemane</name>
 <version>1.1.4</version>
+<created>2023-02-05</created><!--created date derived from commit 00e480dd-->
 <objective>Capture the enemies wool</objective>
 <include id="gapple-kill-reward"/>
 <!-- Map authors & contributors. -->

--- a/ctw/green_gem_ctw/map.xml
+++ b/ctw/green_gem_ctw/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Green Gem CTW</name>
 <version>1.1.4</version>
+<created>2021-01-04</created><!--created date derived from commit a3d80595-->
 <variant id="christmas" world="christmas" override="true">Winter Gem CTW</variant>
 <objective>Capture all 3 wools!</objective>
 <include id="gapple-kill-reward"/>

--- a/ctw/hobbit_ctw/map.xml
+++ b/ctw/hobbit_ctw/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Hobbit CTW</name>
 <version>1.0.10</version>
+<created>2023-02-04</created><!--created date derived from commit c8862671-->
 <include id="gapple-kill-reward"/>
 <variant id="christmas" world="christmas" override="true">Hobbitmas</variant>
 <objective>Take the enemy's wool located near their base and place it back at your spawn!</objective>

--- a/ctw/hotel_overcast/map.xml
+++ b/ctw/hotel_overcast/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Hotel Overcast</name>
 <version>1.3.10</version>
+<created>2021-07-31</created><!--created date derived from commit 1a3613d1-->
 <include id="gapple-kill-reward"/>
 <include id="iron-bulkcrafting"/>
 <objective>Capture the enemy's wools to win!</objective>

--- a/ctw/kanto/map.xml
+++ b/ctw/kanto/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Kanto</name>
 <version>1.5.8</version>
+<created>2022-01-08</created><!--created date derived from commit 982bd04f-->
 <variant id="halloween" world="halloween" override="true">Kant-o'-Lantern</variant>
 <variant id="christmas" world="christmas" override="true">Kanto Claus</variant>
 <objective>Capture the enemy's wools!</objective>

--- a/ctw/kerskyn/map.xml
+++ b/ctw/kerskyn/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Kerskyn</name>
 <version>1.0.4</version>
+<created>2023-02-04</created><!--created date derived from commit c8862671-->
 <objective>Capture both of the enemies wools</objective>
 <include id="gapple-kill-reward"/>
 <!-- Map authors & contributors -->

--- a/ctw/mahatma/map.xml
+++ b/ctw/mahatma/map.xml
@@ -2,6 +2,7 @@
 <name>Mahatma</name>
 <variant id="halloween" world="halloween" override="true">Mahellma</variant>
 <version>1.2.2</version>
+<created>2022-03-11</created><!--created date derived from commit 8b41305a-->
 <objective>Capture all three enemy wools to win!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/mame_i_shrunk_the_pvpers/map.xml
+++ b/ctw/mame_i_shrunk_the_pvpers/map.xml
@@ -2,6 +2,7 @@
 <name>Mame, I Shrunk the PvPers</name>
 <variant id="halloween" world="halloween" override="true">Mame, I Shrunk the Goblins</variant>
 <version>1.2.7</version>
+<created>2023-02-21</created><!--created date derived from commit a0438278-->
 <include id="gapple-kill-reward"/>
 <objective>Capture both of the enemy's wools, and buy upgrades from the villagers to help you do so!</objective>
 <if variant="default">

--- a/ctw/mine_your_own_business/map.xml
+++ b/ctw/mine_your_own_business/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Mine Your Own Business</name>
 <version>1.1.5</version>
+<created>2020-08-23</created><!--created date derived from commit 9ffa3daf-->
 <objective>Bring the other team's wools back to your side.</objective>
 <include id="gapple-kill-reward"/>
 <phase>staging</phase>

--- a/ctw/newgen/map.xml
+++ b/ctw/newgen/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>NewGen</name>
 <version>2.0.6</version>
+<created>2021-07-31</created><!--created date derived from commit 1a3613d1-->
 <variant id="christmas" world="christmas" override="true">SnowGen</variant>
 <variant id="christmas_te" world="christmas" override="true">SnowGen: TE</variant>
 <include id="gapple-kill-reward"/>

--- a/ctw/nyxis/map.xml
+++ b/ctw/nyxis/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Nyxis</name>
 <version>1.0.6</version>
+<created>2023-05-13</created><!--created date derived from commit b737485b-->
 <objective>Obtain the enemy's wool and return it to one of your spawn monuments!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/oasis_ctw/map.xml
+++ b/ctw/oasis_ctw/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Oasis CTW</name>
 <version>1.1.2</version>
+<created>2022-01-29</created><!--created date derived from commit bb20e920-->
 <variant id="christmas" world="christmas">Winter</variant>
 <objective>Capture the enemy team's wool!</objective>
 <if variant="default">

--- a/ctw/outlyne/map.xml
+++ b/ctw/outlyne/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Outlyne</name>
 <version>1.0.2</version>
+<created>2022-10-24</created><!--created date derived from commit 49d98938-->
 <objective>Capture and place the wool at your monument</objective>
 <include id="gapple-kill-reward"/>
 <!-- Map authors & contributors. -->

--- a/ctw/prisma_ctw/map.xml
+++ b/ctw/prisma_ctw/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Prisma CTW</name>
 <version>1.0.3</version>
+<created>2022-09-16</created><!--created date derived from commit 954c3828-->
 <objective>Get the enemy's wool to win!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctw/quadrosphere_ctw/map.xml
+++ b/ctw/quadrosphere_ctw/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Quadrosphere CTW</name>
 <version>1.3.2</version>
+<created>2022-01-08</created><!--created date derived from commit 982bd04f-->
 <objective>Collect dyes from each spawner, get string from kills and craft them together to make the wools for your victory monuments!</objective>
 <variant id="christmas" world="christmas" override="true">Quadromas CTW</variant>
 <variant id="halloween" world="halloween" override="true">Quadroween CTW</variant>

--- a/ctw/ringpull/map.xml
+++ b/ctw/ringpull/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Ringpull</name>
 <version>1.2.3</version>
+<created>2022-03-17</created><!--created date derived from commit 7ecf8416-->
 <objective>Capture the enemy team's wool!</objective>
 <variant id="halloween" world="halloween" override="true">Ringnull</variant>
 <variant id="christmas" world="christmas" override="true">Crackerpull</variant>

--- a/ctw/road_trip_to_sunset_town/map.xml
+++ b/ctw/road_trip_to_sunset_town/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Road Trip to Sunset Town</name>
 <version>2.1.7</version>
+<created>2020-08-16</created><!--created date derived from commit 0497018f-->
 <objective>Capture the other seven teams' wools.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctw/sakura_garden/map.xml
+++ b/ctw/sakura_garden/map.xml
@@ -2,6 +2,7 @@
 <name>Sakura Garden</name>
 <variant id="halloween" world="halloween" override="true">Halloween Garden</variant>
 <version>1.1.1</version>
+<created>2022-02-10</created><!--created date derived from commit 492a7d17-->
 <objective>Capture both wools!</objective>
 <include id="gapple-kill-reward"/>
 <if variant="default">

--- a/ctw/sanctum_wasser/map.xml
+++ b/ctw/sanctum_wasser/map.xml
@@ -2,6 +2,7 @@
 <name>Sanctum Wasser</name>
 <variant id="halloween" world="halloween" override="true">Spooky Sanctum</variant>
 <version>1.0.7</version>
+<created>2023-02-04</created><!--created date derived from commit 9949551a-->
 <objective>Capture the wool!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/santa_clauses/map.xml
+++ b/ctw/santa_clauses/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Santa Clauses</name>
 <version>1.0.3</version>
+<created>2020-12-15</created><!--created date derived from commit dec9c092-->
 <objective>Capture the enemy team's wool.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctw/santorini/map.xml
+++ b/ctw/santorini/map.xml
@@ -2,6 +2,7 @@
 <include id="gapple-kill-reward"/>
 <name>Santorini</name>
 <version>1.0.4</version>
+<created>2024-08-11</created><!--created date derived from commit 4fe685a0-->
 <variant id="christmas" world="christmas" override="true">Santarini</variant>
 <objective>Capture the enemy team's wool!</objective>
 <if variant="default">

--- a/ctw/summertime_at_browns_farms/map.xml
+++ b/ctw/summertime_at_browns_farms/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Summertime at Brown's Farms</name>
 <version>1.0.5</version>
+<created>2020-08-16</created><!--created date derived from commit 93f90dd8-->
 <objective>Capture the other seven teams' wools.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/ctw/tulip_mania/map.xml
+++ b/ctw/tulip_mania/map.xml
@@ -2,6 +2,7 @@
 <name>Tulip Mania</name>
 <variant id="halloween" world="halloween" override="true">Witch Mania</variant>
 <version>1.1.2</version>
+<created>2022-09-17</created><!--created date derived from commit 5c15c2cf-->
 <objective>Capture the enemy team's wool!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/tulip_mania_ii/map.xml
+++ b/ctw/tulip_mania_ii/map.xml
@@ -2,6 +2,7 @@
 <name>Tulip Mania II</name>
 <variant id="halloween" world="halloween" override="true">Witch Mania II</variant>
 <version>1.2.3</version>
+<created>2022-09-28</created><!--created date derived from commit e2dbbcc7-->
 <objective>Capture the enemy team's wools!</objective>
 <gamemode>ctw</gamemode>
 <include id="gapple-kill-reward"/>

--- a/ctw/villa_i/map.xml
+++ b/ctw/villa_i/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Villa I</name>
 <version>1.2.4</version>
+<created>2022-01-08</created><!--created date derived from commit 982bd04f-->
 <variant id="christmas" world="christmas" override="true" slug="chilla">Chilla I</variant>
 <objective>Capture the enemy team's wool!</objective>
 <if variant="default">

--- a/ctw/villa_ii/map.xml
+++ b/ctw/villa_ii/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Villa II</name>
 <version>1.2.5</version>
+<created>2022-08-08</created><!--created date derived from commit 7950cb8c-->
 <variant id="halloween" world="halloween" override="true" slug="villa_ii_boo">Villa BOO</variant>
 <variant id="christmas" world="christmas" override="true">Chilla II</variant>
 <objective>Capture the enemy team's wool!</objective>

--- a/ctw/witchs_potions/map.xml
+++ b/ctw/witchs_potions/map.xml
@@ -3,6 +3,7 @@
 <variant id="halloween" world="halloween" override="true">Scary Potions</variant>
 <variant id="christmas" world="christmas" override="true">Santa's Gifts</variant>
 <version>1.1.1</version>
+<created>2022-06-21</created><!--created date derived from commit 9677f764-->
 <objective>Capture the wool!</objective>
 <include id="gapple-kill-reward"/>
 <if variant="default">

--- a/dtcm/aquatica/map.xml
+++ b/dtcm/aquatica/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Aquatica</name>
 <version>1.5.3</version>
+<created>2022-03-27</created><!--created date derived from commit d9756e44-->
 <variant id="halloween" world="halloween" override="true">SpOOkatica</variant>
 <objective>Destroy the enemy team's emerald monument!</objective>
 <include id="gapple-kill-reward"/>

--- a/dtcm/beehive/map.xml
+++ b/dtcm/beehive/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Beehive</name>
 <version>1.2.7</version>
+<created>2021-05-12</created><!--created date derived from commit 7b484644-->
 <objective>Break the other team's obsidian monuments.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/extraterrestrial/map.xml
+++ b/dtcm/extraterrestrial/map.xml
@@ -4,6 +4,7 @@
 <variant id="christmas" world="christmas">Sub-Zero</variant>
 <objective>Leak the enemy's core!</objective>
 <version>1.1.8</version>
+<created>2023-07-02</created><!--created date derived from commit ccce08d8-->
 <gamemode>dtc</gamemode>
 <if variant="default">
     <created>2023-06-21</created>

--- a/dtcm/hearts_of_atlantis/map.xml
+++ b/dtcm/hearts_of_atlantis/map.xml
@@ -2,6 +2,7 @@
 <name>Hearts of Atlantis</name>
 <variant id="halloween" world="halloween" override="true">Hearts of Hades</variant>
 <version>1.1.2</version>
+<created>2022-07-16</created><!--created date derived from commit b5fa1bca-->
 <objective>Leak the enemy team's obsidian core!</objective>
 <gamemode>dtc</gamemode>
 <include id="gapple-kill-reward"/>

--- a/dtcm/home_by_the_sea/map.xml
+++ b/dtcm/home_by_the_sea/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Home by the Sea</name>
 <version>1.0.6</version>
+<created>2023-04-06</created><!--created date derived from commit c5bb71d2-->
 <variant id="halloween" world="halloween" override="true">Images of Sorrow</variant>
 <objective>Destroy the enemy team's emerald monument!</objective>
 <constant id="wood-damage">2</constant>

--- a/dtcm/island_divide/map.xml
+++ b/dtcm/island_divide/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Island Divide</name>
 <version>1.1.6</version>
+<created>2023-04-06</created><!--created date derived from commit af051eda-->
 <objective>Destroy the opponent's monuments at the opposite side of the island and enjoy the sun!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/iti_moai/map.xml
+++ b/dtcm/iti_moai/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Iti Mo'ai</name>
 <version>1.3.2</version>
+<created>2022-05-12</created><!--created date derived from commit 31f86ab7-->
 <variant id="christmas" world="christmas" override="true">Iti Marshmallow Mo'ai</variant>
 <variant id="halloween" world="halloween" override="true">Iti Boo'ai</variant>
 <objective>Destroy the enemy's emerald monument!</objective>

--- a/dtcm/little_roses/map.xml
+++ b/dtcm/little_roses/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Little Roses</name>
 <version>1.0.5</version>
+<created>2023-02-20</created><!--created date derived from commit b9cbed99-->
 <objective>Destroy the enemy team's obsidian monument!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/maze_mountain_madness/map.xml
+++ b/dtcm/maze_mountain_madness/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Maze Mountain Madness</name>
 <version>1.0.3</version>
+<created>2022-08-03</created><!--created date derived from commit 913b3592-->
 <objective>Destroy all three monuments of the enemy team.</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/medieval_village/map.xml
+++ b/dtcm/medieval_village/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Medieval Village</name>
 <version>1.1.8</version>
+<created>2022-07-06</created><!--created date derived from commit 919dd1b6-->
 <variant id="christmas" world="christmas" override="true">Christmas Village</variant>
 <objective>Leak lava from the enemy's obsidian core!</objective>
 <unless variant="christmas">

--- a/dtcm/missingno/map.xml
+++ b/dtcm/missingno/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>MissingNo</name>
 <version>1.1.4</version>
+<created>2023-02-05</created><!--created date derived from commit 7911f357-->
 <variant id="christmas" world="christmas" override="true">FrostyNo</variant>
 <objective>Destroy the enemy team's obsidian monument!</objective>
 <include id="gapple-kill-reward"/>

--- a/dtcm/mushroom_monuments/map.xml
+++ b/dtcm/mushroom_monuments/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Mushroom Monuments</name>
 <version>1.2.3</version>
+<created>2022-01-08</created><!--created date derived from commit 982bd04f-->
 <variant id="christmas" world="christmas" override="true">Chillshroom Monuments</variant>
 <variant id="halloween" world="halloween" override="true">Booshroom Monuments</variant>
 <objective>Destroy the enemy team's monument!</objective>

--- a/dtcm/natsukashii/map.xml
+++ b/dtcm/natsukashii/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Natsukashii</name>
 <version>1.3.3</version>
+<created>2021-03-31</created><!--created date derived from commit e739a64f-->
 <objective>Destroy the enemy team's monument!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/osoi/map.xml
+++ b/dtcm/osoi/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Osoi</name>
 <version>1.2.3</version>
+<created>2023-07-17</created><!--created date derived from commit 682eb1a5-->
 <objective>Destroy the enemy's monuments!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/parabola/map.xml
+++ b/dtcm/parabola/map.xml
@@ -2,6 +2,7 @@
 <name>Parabola</name>
 <variant id="halloween" world="halloween">Halloween</variant>
 <version>2.0.6</version>
+<created>2022-01-30</created><!--created date derived from commit 3ea3a977-->
 <objective>Destroy both of the enemy team's monuments!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/quintlet/map.xml
+++ b/dtcm/quintlet/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Quintlet</name>
 <version>1.0.3</version>
+<created>2022-02-04</created><!--created date derived from commit 91341c4e-->
 <objective>Break all 5 monuments!</objective>
 <include id="gapple-kill-reward"/>
 <authors>

--- a/dtcm/rind_rushers/map.xml
+++ b/dtcm/rind_rushers/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Rind Rushers</name>
 <version>1.1.1</version>
+<created>2022-09-07</created><!--created date derived from commit bb9c80f4-->
 <variant id="christmas" world="christmas" override="true">Rednose Rushers</variant>
 <objective>Destroy the enemy's monument!</objective>
 <if variant="default">

--- a/dtcm/royal_ascend/map.xml
+++ b/dtcm/royal_ascend/map.xml
@@ -2,6 +2,7 @@
 <name>Royal Ascend</name>
 <variant id="halloween" world="halloween" override="true">BOOyal Ascend</variant>
 <version>1.1.5</version>
+<created>2023-02-05</created><!--created date derived from commit 7911f357-->
 <objective>Leak lava from the enemy core and destroy the enemy monuments!</objective>
 <include id="gapple-kill-reward"/>
 <unless variant="halloween">

--- a/dtcm/scrapelli/map.xml
+++ b/dtcm/scrapelli/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Scrapelli</name>
 <version>1.0.6</version>
+<created>2024-05-12</created><!--created date derived from commit fa455c21-->
 <variant id="christmas" world="christmas" override="true">Snowpelli</variant>
 <objective>Destroy the enemy team's monument!</objective>
 <include id="gapple-kill-reward"/>

--- a/dtcm/the_waiting_room/map.xml
+++ b/dtcm/the_waiting_room/map.xml
@@ -2,6 +2,7 @@
 <name>The Waiting Room</name>
 <variant id="halloween" world="halloween" override="true">The Carving Room</variant>
 <version>1.3.5</version>
+<created>2023-07-02</created><!--created date derived from commit ccce08d8-->
 <objective>Destroy the other team's side ladder monuments to win!</objective>
 <gamemode>dtm</gamemode>
 <if variant="default">

--- a/dtcm/tohjo_falls/map.xml
+++ b/dtcm/tohjo_falls/map.xml
@@ -2,6 +2,7 @@
 <name>Tohjo Falls</name>
 <variant id="halloween" world="halloween" override="true">Styx Falls</variant>
 <version>1.1.2</version>
+<created>2023-01-07</created><!--created date derived from commit a16a954b-->
 <objective>Destroy the enemy team's monument!</objective>
 <gamemode>dtm</gamemode>
 <include id="gapple-kill-reward"/>

--- a/dtcm/total_beesness/map.xml
+++ b/dtcm/total_beesness/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Total Beesness</name>
 <version>1.0.6</version>
+<created>2022-11-18</created><!--created date derived from commit d32dabfb-->
 <include id="gapple-kill-reward"/>
 <objective>Destroy the enemies monuments!</objective>
 <!-- Map authors & contributors -->

--- a/dtcm/wild_isle/map.xml
+++ b/dtcm/wild_isle/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Wild Isle</name>
 <version>1.4.5</version>
+<created>2021-10-17</created><!--created date derived from commit f8c3a3de-->
 <variant id="christmas" world="christmas" override="true">Snowy Isle</variant>
 <variant id="halloween" world="halloween" override="true">Wild Vile</variant>
 <objective>Destroy both enemy monuments!</objective>

--- a/ffa/paint_cant_wait_2/map.xml
+++ b/ffa/paint_cant_wait_2/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0" game="Painters">
 <name>Paint Can't Wait 2</name>
 <version>1.0.1</version>
+<created>2022-09-27</created><!--created date derived from commit 856949b2-->
 <objective>Paint most of the map to win!</objective>
 <authors>
     <author uuid="b03360db-b8cd-49de-8ba1-b7920c2238a9" contribution="Map author"/> <!-- Obelistics -->

--- a/ffa/paladin_banners/map.xml
+++ b/ffa/paladin_banners/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Paladin Banners</name>
 <version>1.2.1</version>
+<created>2022-04-28</created><!--created date derived from commit 0f5ea6c5-->
 <objective>Get the most points, by killing or controlling banners!</objective>
 <include id="gapple-kill-reward"/>
 <phase>staging</phase>

--- a/kotf/bazaar_kotf/map.xml
+++ b/kotf/bazaar_kotf/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Bazaar KotF</name>
 <version>1.0.4</version>
+<created>2023-08-13</created><!--created date derived from commit 5b8cabf7-->
 <include id="kotf"/>
 <constant id="score">150</constant>
 <constant id="damage-resistance">0s</constant>

--- a/kotf/boulevard/map.xml
+++ b/kotf/boulevard/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Boulevard</name>
 <version>1.0.6</version>
+<created>2022-07-09</created><!--created date derived from commit 2eaf8c59-->
 <include id="kotf"/>
 <constant id="score">180</constant>
 <constant id="damage-resistance">3.5s</constant>

--- a/kotf/crater_resort/map.xml
+++ b/kotf/crater_resort/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Crater Resort</name>
 <version>1.0.4</version>
+<created>2023-05-12</created><!--created date derived from commit 0cfc5688-->
 <objective>Hold the flag for 150 seconds to win!</objective>
 <gamemode>kotf</gamemode>
 <include id="gapple-kill-reward"/>

--- a/kotf/desert_sanctuary_2.0/map.xml
+++ b/kotf/desert_sanctuary_2.0/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Desert Sanctuary 2.0</name>
 <version>1.0.3</version>
+<created>2023-09-26</created><!--created date derived from commit 83ddcc3a-->
 <include id="kotf"/>
 <constant id="respawn-timer">4s</constant>
 <constant id="damage-resistance">7.5s</constant>

--- a/kotf/desert_sanctuary_mini/map.xml
+++ b/kotf/desert_sanctuary_mini/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Desert Sanctuary Mini</name>
 <version>1.2</version>
+<created>2024-12-06</created><!--created date derived from commit 2e30c2cd-->
 <objective>Control the flag for ${score} seconds to win!</objective>
 <constant id="damage-resistance">6s</constant>
 <constant id="respawn-timer">5s</constant>

--- a/kotf/embargo/map.xml
+++ b/kotf/embargo/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Embargo</name>
 <version>1.1.2</version>
+<created>2023-02-05</created><!--created date derived from commit b4dfb7d8-->
 <variant id="5v5">5v5</variant>
 <unless variant="5v5">
     <include id="kotf"/>

--- a/kotf/manzikert/map.xml
+++ b/kotf/manzikert/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Manzikert</name>
 <version>1.0.7</version>
+<created>2024-09-02</created><!--created date derived from commit 7d6cb90f-->
 <variant id="5v5">5v5</variant>
 <constant id="damage-resistance">6s</constant>
 <constant id="announce-post-pickup">true</constant>

--- a/kotf/west_rider/map.xml
+++ b/kotf/west_rider/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>West Rider</name>
 <version>1.1.8</version>
+<created>2022-10-13</created><!--created date derived from commit 59d4496b-->
 <variant id="5v5">5v5</variant>
 <unless variant="5v5">
     <include id="kotf"/>

--- a/kotf/zipline/map.xml
+++ b/kotf/zipline/map.xml
@@ -5,6 +5,7 @@
 <variant id="gunz">Moar Gunz Edition</variant>
 <include id="gapple-kill-reward"/>
 <version>1.1.6</version>
+<created>2020-08-29</created><!--created date derived from commit 6934a7f9-->
 <objective>Hold the flag for 200 seconds to win!</objective>
 <gamemode>kotf</gamemode>
 <if variant="default">

--- a/koth/ab33d/map.xml
+++ b/koth/ab33d/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Ab33d</name>
 <version>1.0.1</version>
+<created>2023-08-24</created><!--created date derived from commit 973fc690-->
 <objective>Be the first team to gain 450 points.</objective>
 <include id="gapple-kill-reward"/>
 <phase>staging</phase>

--- a/koth/abaddon_koth/map.xml
+++ b/koth/abaddon_koth/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Abaddon KOTH</name>
 <version>2.2.2</version>
+<created>2023-09-20</created><!--created date derived from commit eefa28b9-->
 <objective>Get the most points by holding the hills!</objective>
 <gamemode>koth</gamemode>
 <include id="gapple-kill-reward"/>

--- a/koth/abood/map.xml
+++ b/koth/abood/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Abood</name>
 <version>1.0.7</version>
+<created>2023-08-24</created><!--created date derived from commit 973fc690-->
 <include id="conquest-comp"/>
 <constant id="respawn-timer">3s</constant>
 <constant id="damage-resistance">6s</constant>

--- a/koth/biotech/map.xml
+++ b/koth/biotech/map.xml
@@ -3,6 +3,7 @@
 <variant id="halloween" world="halloween" override="true">Biohazard</variant>
 <variant id="5v5" world="5v5">5v5</variant>
 <version>1.1.2</version>
+<created>2022-04-30</created><!--created date derived from commit 2dad265f-->
 <unless variant="5v5">
     <include id="conquest"/>
     <constant id="respawn-timer">3s</constant>

--- a/koth/byas/map.xml
+++ b/koth/byas/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Byas</name>
 <version>1.0.4</version>
+<created>2022-09-30</created><!--created date derived from commit 3a70974d-->
 <objective>Be the first team to 500 points</objective>
 <include id="gapple-kill-reward"/>
 <!-- Map authors & contributors. -->

--- a/koth/catre_koth/map.xml
+++ b/koth/catre_koth/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Catre KotH</name>
 <version>1.0.5</version>
+<created>2022-09-17</created><!--created date derived from commit 143c182b-->
 <objective>Capture and hold the hills to score points</objective>
 <gamemode>koth</gamemode>
 <include id="conquest"/>

--- a/koth/disc_wars_iii/map.xml
+++ b/koth/disc_wars_iii/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Disc Wars III</name>
 <version>1.2.4</version>
+<created>2022-12-10</created><!--created date derived from commit 1a883401-->
 <objective>Capture the hills to be the first team to 2500 points!</objective>
 <authors>
     <author uuid="4011d739-4dfb-41f6-8e60-5179d035cab7"/> <!-- MishM0sh -->

--- a/koth/industrial/map.xml
+++ b/koth/industrial/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Industrial</name>
 <version>1.4.5</version>
+<created>2022-11-30</created><!--created date derived from commit e496efad-->
 <variant id="5v5">5v5</variant>
 <unless variant="5v5">
     <include id="conquest"/>

--- a/koth/mago/map.xml
+++ b/koth/mago/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Mago</name>
 <version>1.2.2</version>
+<created>2022-11-30</created><!--created date derived from commit e496efad-->
 <edition>standard</edition>
 <objective>First team to 750 points win!</objective>
 <include id="gapple-kill-reward"/>

--- a/koth/quadrosphere_rage/map.xml
+++ b/koth/quadrosphere_rage/map.xml
@@ -3,6 +3,7 @@
 <variant id="halloween" world="halloween" override="true">Quadroween Rage</variant>
 <variant id="christmas" world="christmas" override="true">Quadromas Rage</variant>
 <version>1.1.6</version>
+<created>2022-02-04</created><!--created date derived from commit 91341c4e-->
 <objective>Be the team with the most points after 8 minutes!</objective>
 <gamemode>koth</gamemode>
 <gamemode>rage</gamemode>

--- a/koth/rafiki/map.xml
+++ b/koth/rafiki/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Rafiki</name>
 <version>1.0.3</version>
+<created>2022-11-15</created><!--created date derived from commit 3560a5b7-->
 <objective>Be the first to 500 points</objective>
 <gamemode>koth</gamemode>
 <include id="gapple-kill-reward"/>

--- a/koth/stratosphere_rage/map.xml
+++ b/koth/stratosphere_rage/map.xml
@@ -3,6 +3,7 @@
 <variant id="halloween" world="halloween" override="true">Stratoween Rage</variant>
 <variant id="christmas" world="christmas" override="true">Stratomas Rage</variant>
 <version>1.4.4</version>
+<created>2021-11-05</created><!--created date derived from commit dd1c4465-->
 <objective>Be the team with the most points after 8 minutes!</objective>
 <gamemode>koth</gamemode>
 <gamemode>rage</gamemode>

--- a/koth/the_end_koth/map.xml
+++ b/koth/the_end_koth/map.xml
@@ -18,6 +18,7 @@
 </if>
 <constant id="damage-resistance">4s</constant>
 <version>1.2.5</version>
+<created>2022-11-30</created><!--created date derived from commit e496efad-->
 <objective>Be the first team to reach 750 points!</objective>
 <authors>
     <author uuid="5198dc37-537f-4ea5-8ee8-1e0952d4a36b"/> <!-- _3Each -->

--- a/koth/war_for_iacon/map.xml
+++ b/koth/war_for_iacon/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>War for Iacon</name>
 <version>1.0.1</version>
+<created>2023-03-09</created><!--created date derived from commit f6a5b630-->
 <phase>staging</phase>
 <objective>Be the first team to reach 750 points!</objective>
 <gamemode>koth</gamemode>

--- a/koth/yukoth/map.xml
+++ b/koth/yukoth/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Yukoth</name>
 <version>2.0.2</version>
+<created>2024-03-02</created><!--created date derived from commit dfa7bdd0-->
 <objective>Be the first team to reach 444 points.</objective>
 <authors>
     <author uuid="2ca8072f-74be-4798-85b8-bbce03aa91af"/> <!-- Tywnis -->

--- a/mixed/moai/map.xml
+++ b/mixed/moai/map.xml
@@ -2,6 +2,7 @@
 <name>Mo'ai</name>
 <variant id="halloween" world="halloween" override="true">Boo'ai</variant>
 <version>1.4.2</version>
+<created>2022-02-26</created><!--created date derived from commit d8303fe8-->
 <objective>Destroy the enemy's monument, then capture their two wools!</objective>
 <if variant="default">
     <created>2022-02-24</created>

--- a/other/ctp/tug_of_war/map.xml
+++ b/other/ctp/tug_of_war/map.xml
@@ -10,6 +10,7 @@
     <created>2023-04-26</created>
 </if>
 <version>1.0.5</version>
+<created>2023-05-24</created><!--created date derived from commit 2fe4de5b-->
 <include id="gapple-kill-reward"/>
 <include id="void-death"/>
 <objective>Capture all the points sequentially in the row to win!</objective>

--- a/other/gs/life_o_rama/map.xml
+++ b/other/gs/life_o_rama/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Life-O-Rama</name>
 <version>1.0</version>
+<created>2024-12-21</created><!--created date derived from commit d726f82e-->
 <include id="gs"/>
 <include id="lifesteal"/>
 <include id="void-death"/>

--- a/scorebox/aurosphere/map.xml
+++ b/scorebox/aurosphere/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Aurosphere</name>
 <version>1.3.1</version>
+<created>2022-03-17</created><!--created date derived from commit ae8a5fbf-->
 <variant id="christmas" world="christmas" override="true">Auromas</variant>
 <variant id="halloween" world="halloween" override="true">Auroween</variant>
 <objective>Collect gold nuggets and jump in the scorebox with them for points!</objective>

--- a/scorebox/bob-omb_battlefield/map.xml
+++ b/scorebox/bob-omb_battlefield/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Bob-Omb Battlefield</name>
 <version>1.3.3</version>
+<created>2022-04-04</created><!--created date derived from commit 50691699-->
 <variant id="christmas" world="christmas" override="true">Chief Chilly's Battlefield</variant>
 <variant id="halloween" world="halloween" override="true">King Boo's Battlefield</variant>
 <objective>Kill enemies for stars, drop into the pipe with them for points!</objective>

--- a/scorebox/miner_sixty_niner/map.xml
+++ b/scorebox/miner_sixty_niner/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Miner Sixty Niner</name>
 <version>1.5.2</version>
+<created>2020-10-27</created><!--created date derived from commit f31bd4c3-->
 <variant id="halloween" world="halloween" override="true">Die Noon</variant>
 <variant id="christmas" world="christmas" override="true">Fistful of Cookies</variant>
 <objective>Kill enemies for ${objective-item-displayname}, drop into the chute with them for points!</objective>

--- a/scorebox/zap_ii/map.xml
+++ b/scorebox/zap_ii/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Zap II</name>
 <version>1.0.2</version>
+<created>2023-08-11</created><!--created date derived from commit ff91a669-->
 <phase>staging</phase>
 <objective>Have the highest amount of points in 12 minutes! 1 kill is worth 3 points, 1 scorebox entry is worth 10!</objective>
 <gamemode>scorebox</gamemode>

--- a/tdm/charge_station/map.xml
+++ b/tdm/charge_station/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Charge Station</name>
 <version>1.0.5</version>
+<created>2023-01-10</created><!--created date derived from commit d2ba18e8-->
 <objective>Get the most kills after 8 minutes!</objective>
 <gamemode>tdm</gamemode>
 <include id="gapple-kill-reward"/>

--- a/tdm/transit/map.xml
+++ b/tdm/transit/map.xml
@@ -2,6 +2,7 @@
 <name>Transit</name>
 <variant id="halloween" world="halloween">Halloween Edition</variant>
 <version>1.2.7</version>
+<created>2022-07-30</created><!--created date derived from commit 814c011e-->
 <objective>Bombers should get to the scorebox and Guards should block their way!</objective>
 <constant id="bomber-color-code">FF0C0C</constant>
 <constant id="guard-color-code">FFCC0C</constant>

--- a/tdm/two/map.xml
+++ b/tdm/two/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Two</name>
 <version>1.0.2</version>
+<created>2020-09-14</created><!--created date derived from commit 8bed8a2e-->
 <objective>Eliminate as many enemies as you can.</objective>
 <gamemode>tdm</gamemode>
 <include id="gapple-kill-reward"/>

--- a/tdm/wrath_tor_rage/map.xml
+++ b/tdm/wrath_tor_rage/map.xml
@@ -1,6 +1,7 @@
 <map proto="1.5.0">
 <name>Wrath Tor RAGE</name>
 <version>1.4.10</version>
+<created>2022-03-31</created><!--created date derived from commit 7247cc7b-->
 <objective>Kill enemy players and redeem emeralds in their scorebox to have the most points!</objective>
 <gamemode>rage</gamemode>
 <gamemode>scorebox</gamemode>


### PR DESCRIPTION
This PR adds a creation date to maps which don't have one.

I used the command `git log --follow -M level.dat` to get the oldest commit for each map. In order to confirm this works at all, I compared this predicted date to existing map `<creation>` tags.
mean difference: ~125 days
median difference: 5 days

This will definitely be wrong for some maps, but seems to be pretty close for most. I have given most of these maps a cursory glance, but obviously I don't know the history of some of these maps, so hopefully someone else can look at them as well.