### PR TITLE
Water Drop Pride Gamer Edition: Prevent pvp at spawn platform

### DIFF
--- a/arcade/standard/water_drop_pride_gamer_edition/map.xml
+++ b/arcade/standard/water_drop_pride_gamer_edition/map.xml
@@ -23,7 +23,7 @@
         <item slot="1" material="water bucket"/>
         <item slot="2" material="water bucket"/>
         <boots material="leather boots" team-color="true" locked="true" unbreakable="true" name="`oWater Dropper Boots"/>
-        <potion amplifier="50">weakness</potion>
+        <effect amplifier="50">weakness</effect>
         <max-health>10</max-health>
     </kit>
     <kit id="remove-spawn-prot" force="true">

--- a/arcade/standard/water_drop_pride_gamer_edition/map.xml
+++ b/arcade/standard/water_drop_pride_gamer_edition/map.xml
@@ -27,7 +27,7 @@
         <max-health>10</max-health>
     </kit>
     <kit id="remove-spawn-prot" force="true">
-        <potion amplifier="50" duration="1">weakness</potion>
+        <effect amplifier="50" duration="1">weakness</effect>
     </kit>
     <kit id="void-death-kit" force="true">
         <health>1</health>

--- a/arcade/standard/water_drop_pride_gamer_edition/map.xml
+++ b/arcade/standard/water_drop_pride_gamer_edition/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <game>Water Drop</game>
 <name>Water Drop: Pride Gamer Edition</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <created>2022-09-11</created>
 <objective>Be the first to score three points!</objective>
 <authors>
@@ -18,19 +18,25 @@
     <default yaw="90" region="spawn-point"/>
 </spawns>
 <kits>
-    <kit id="player-kit">
+    <kit id="player-kit" force="true">
         <item slot="0" material="water bucket"/>
         <item slot="1" material="water bucket"/>
         <item slot="2" material="water bucket"/>
         <boots material="leather boots" team-color="true" locked="true" unbreakable="true" name="`oWater Dropper Boots"/>
+        <potion amplifier="50">weakness</potion>
         <max-health>10</max-health>
+    </kit>
+    <kit id="remove-spawn-prot" force="true">
+        <potion amplifier="50" duration="1">weakness</potion>
     </kit>
     <kit id="void-death-kit" force="true">
         <health>1</health>
     </kit>
 </kits>
 <regions>
-    <cuboid id="spawn" min="3,199,-4" max="-4,204,5"/>
+    <negative id="not-spawn">
+        <cuboid id="spawn" min="3,199,-4" max="-4,204,5"/>
+    </negative>
     <cylinder id="spawn-point" base="-0.5,199,0.5" radius="2" height="0"/>
     <cuboid id="scorebox" min="-96,144,-2" max="-101,145,3"/>
     <above id="above-spawn" y="201"/>
@@ -55,6 +61,7 @@
             </union>
         </region>
     </apply>
+    <apply kit="remove-spawn-prot" region="not-spawn"/>
     <apply kit="void-death-kit">
         <region><below y="-5"/></region>
     </apply>


### PR DESCRIPTION
I had a blast dropping a 26 kill streak from the spawn platform, but it sure ruins everyone else's fun. I basically just took my xml from Water Drop: II. The weakness prevents pvp on the top spawn region, and then removes it as soon as the players jump off.