### PR TITLE
Pipes and Punters: Deny entry for flag carriers to their side

### DIFF
--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Pipes and Punters</name>
-<version>1.5</version>
+<version>1.6.0</version>
 <variant id="christmas" world="christmas" override="true">Penguins and Punters</variant>
 <variant id="halloween" world="halloween" override="true">Boo Pipes</variant>
 <objective>Score the flag in the enemy's pipe as many times as possible!</objective>
@@ -79,18 +79,18 @@
     <union id="sides">
         <rectangle id="team-1-side" min="-30,-15" max="31,-71"/>
         <rectangle id="team-2-side" min="-30,16" max="31,72"/>
+        <cuboid id="team-1-side-c" min="-29.5,10,-23.5" max="30.5,40,-43.5"/>
+        <cuboid id="team-2-side-c" min="30.5,10,24.5" max="-29.5,40,44.5"/>
     </union>
     <union id="nets">
         <cylinder id="team-1-net" base="0.5,16,-51.5" radius="4" height="1"/>
         <cylinder id="team-2-net" base="0.5,16,52.5" radius="4" height="1"/>
-        <cylinder id="team-1-net-exclusion" base="0.5,16,-51.5" radius="3.5" height="7"/>
-        <cylinder id="team-2-net-exclusion" base="0.5,16,52.5" radius="3.5" height="7"/>
     </union>
     <negative id="resistance-area">
         <circle id="team-1-coin" center="0.5,30.5" radius="6"/>
         <circle id="team-2-coin" center="0.5,-29.5" radius="6"/>
     </negative>
-    <apply enter="only-team-1" region="team-1-net-exclusion" message="You may not enter your own pipe!"/>
-    <apply enter="only-team-2" region="team-2-net-exclusion" message="You may not enter your own pipe!"/>
+    <apply enter="deny(team-1-carrying-flag)" region="team-2-side-c" message="You cannot return to your side while holding the flag!"/>
+    <apply enter="deny(team-2-carrying-flag)" region="team-1-side-c" message="You cannot return to your side while holding the flag!"/>
 </regions>
 </map>


### PR DESCRIPTION
- This Pull Request will prevent flag carriers from rotating back to their side, specific region is shown in the attached [video](https://cdn.discordapp.com/attachments/172382420954251264/1379214227482480660/uncapped_MedalTVLunarClient20250603003512.mp4?ex=68401598&is=683ec418&hm=311df762b6cbe59b46c309675fa2accd63d96a09ef97503584ed34dc4bd4cc82&l)
- Removed redundant exclusion net areas, as players can no longer reach their own goal area.

Would like to play test these changes and adjust further (if there are any adjustments needed) based on feedback.

The changes above have also been tested on a 1.8 private local testing server to ensure compatibility.