### PR TITLE
Pipes and Punters: Fix Knockback and add duration to Resistance

### DIFF
--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Pipes and Punters</name>
-<version>1.6.0</version>
+<version>1.6.1</version>
 <variant id="christmas" world="christmas" override="true">Penguins and Punters</variant>
 <variant id="halloween" world="halloween" override="true">Boo Pipes</variant>
 <objective>Score the flag in the enemy's pipe as many times as possible!</objective>
@@ -49,8 +49,8 @@
     <kit id="map-spawn-kit" parent="default-kit">
         <kit id="spawn-kit"/>
         <kit id="resistance-kit">
-            <knockback-reduction>0</knockback-reduction>
-            <effect amplifier="5">damage resistance</effect>
+            <knockback-reduction>1</knockback-reduction>
+            <effect duration="4s" amplifier="255">damage resistance</effect>
         </kit>
     </kit>
     <take kit="resistance-kit">

--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -48,17 +48,12 @@
 <kits>
     <kit id="map-spawn-kit" parent="default-kit">
         <kit id="spawn-kit"/>
-        <knockback-reduction>1</knockback-reduction>
+        <kit id="knockback-reduction">
+            <knockback-reduction>1</knockback-reduction>
+        </kit>
         <effect duration="4s" amplifier="5">damage resistance</effect>
     </kit>
-    <take>
-        <kit>
-            <knockback-reduction>0</knockback-reduction>
-        </kit>
-        <filter>
-            <region id="resistance-area"/>
-        </filter>
-    </take>
+    <take kit="knockback-reduction" filter="not(resistance-area)"/>
 </kits>
 <spawns>
     <default kit="default-kit">
@@ -84,10 +79,10 @@
         <cylinder id="team-1-net" base="0.5,16,-51.5" radius="4" height="1"/>
         <cylinder id="team-2-net" base="0.5,16,52.5" radius="4" height="1"/>
     </union>
-    <negative id="resistance-area">
+    <union id="resistance-area">
         <circle id="team-1-coin" center="0.5,30.5" radius="6"/>
         <circle id="team-2-coin" center="0.5,-29.5" radius="6"/>
-    </negative>
+    </union>
     <apply enter="deny(team-1-carrying-flag)" region="team-2-side-c" message="You cannot return to your side while holding the flag!"/>
     <apply enter="deny(team-2-carrying-flag)" region="team-1-side-c" message="You cannot return to your side while holding the flag!"/>
 </regions>

--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -48,17 +48,15 @@
 <kits>
     <kit id="map-spawn-kit" parent="default-kit">
         <kit id="spawn-kit"/>
-        <kit id="resistance-kit">
-            <knockback-reduction>1</knockback-reduction>
-            <effect duration="4s" amplifier="5">damage resistance</effect>
-        </kit>
+        <knockback-reduction>1</knockback-reduction>
+        <effect duration="4s" amplifier="5">damage resistance</effect>
     </kit>
-    <take kit="resistance-kit">
+    <take>
+        <kit>
+            <knockback-reduction>0</knockback-reduction>
+        </kit>
         <filter>
-            <any>
-                <region id="resistance-area"/>
-                <carrying-flag>flag</carrying-flag>
-            </any>
+            <region id="resistance-area"/>
         </filter>
     </take>
 </kits>

--- a/ctf/pipes_and_punters/map.xml
+++ b/ctf/pipes_and_punters/map.xml
@@ -50,7 +50,7 @@
         <kit id="spawn-kit"/>
         <kit id="resistance-kit">
             <knockback-reduction>1</knockback-reduction>
-            <effect duration="4s" amplifier="255">damage resistance</effect>
+            <effect duration="4s" amplifier="5">damage resistance</effect>
         </kit>
     </kit>
     <take kit="resistance-kit">


### PR DESCRIPTION
- Added a 4-second duration to the resistance effect instead of it defaulting to infinite
- Fixed knockback reduction as its value was set to 0, so players will still be able to take knockback in spawn.

These changes have been tested on a private local testing server to ensure compatibility.