### PR TITLE
Kanto: 1.5.9

### DIFF
--- a/ctw/kanto/map.xml
+++ b/ctw/kanto/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Kanto</name>
-<version>1.5.8</version>
+<version>1.5.9</version>
 <variant id="halloween" world="halloween" override="true">Kant-o'-Lantern</variant>
 <variant id="christmas" world="christmas" override="true">Kanto Claus</variant>
 <objective>Capture the enemy's wools!</objective>
@@ -27,16 +27,16 @@
 </contributors>
 <teams>
     <if variant="default">
-        <team id="red" color="dark red" max="24">Red</team>
-        <team id="blue" color="blue" max="24">Blue</team>
+        <team id="red-team" color="dark red" max="24">Red</team>
+        <team id="blue-team" color="blue" max="24">Blue</team>
     </if>
     <if variant="halloween">
-        <team id="red" color="dark green" max="24">Green</team>
-        <team id="blue" color="dark purple" max="24">Purple</team>
+        <team id="red-team" color="dark green" max="24">Green</team>
+        <team id="blue-team" color="dark purple" max="24">Purple</team>
     </if>
     <if variant="christmas">
-        <team id="red" color="dark red" max="24">Red</team>
-        <team id="blue" color="dark green" max="24">Green</team>
+        <team id="red-team" color="dark red" max="24">Red</team>
+        <team id="blue-team" color="dark green" max="24">Green</team>
     </if>
 </teams>
 <kits>
@@ -61,12 +61,10 @@
 </kits>
 <spawns>
     <default yaw="90" region="obs-spawn-point"/>
-    <spawn team="blue" kit="spawn-kit" region="blue-spawn-point"/>
-    <spawn team="red" kit="spawn-kit" yaw="180" region="red-spawn-point"/>
+    <spawn team="blue-team" kit="spawn-kit" region="blue-spawn-point"/>
+    <spawn team="red-team" kit="spawn-kit" yaw="180" region="red-spawn-point"/>
 </spawns>
 <filters>
-    <team id="only-blue">blue</team>
-    <team id="only-red">red</team>
     <deny id="deny-some-world">
         <all>
             <cause>world</cause>
@@ -78,14 +76,11 @@
             </not>
         </all>
     </deny>
-    <deny id="deny-beacon">
-        <material>beacon</material>
-    </deny>
+    <material id="only-beacon">beacon</material>
     <all id="only-iron-renew">
         <material id="only-iron">iron block</material>
         <cause>world</cause>
     </all>
-    <material id="only-air">air</material>
 </filters>
 <regions>
     <union id="spawn-points">
@@ -127,38 +122,38 @@
         <rectangle min="-10,12" max="-27,-11"/> <!-- west mid build region -->
     </complement>
     <apply use="deny(void)" region="void-area"/>
-    <apply use="only-blue" region="red-wool-rooms"/>
-    <apply use="only-red" region="blue-wool-rooms"/>
-    <apply use="deny-beacon" message="You may not use the beacon!"/>
+    <apply use="deny(red-team)" region="red-wool-rooms"/>
+    <apply use="deny(blue-team)" region="blue-wool-rooms"/>
+    <apply use="deny(only-beacon)" message="You may not use the beacon!"/>
     <apply block="deny-some-world" region="wool-rooms"/>
-    <apply enter="only-blue" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-red" region="red-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-blue" region="red-wool-rooms" message="You may not enter your own wool room!"/>
-    <apply enter="only-red" region="blue-wool-rooms" message="You may not enter your own wool room!"/>
-    <apply block="only-red" region="blue-wool-rooms" message="You may not edit your own wool room!"/>
-    <apply block="only-blue" region="red-wool-rooms" message="You may not edit your own wool room!"/>
+    <apply enter="deny(red-team)" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(blue-team)" region="red-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(red-team)" region="red-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply enter="deny(blue-team)" region="blue-wool-rooms" message="You may not enter your own wool room!"/>
+    <apply block="deny(red-team)" region="red-wool-rooms" message="You may not edit your own wool room!"/>
+    <apply block="deny(blue-team)" region="blue-wool-rooms" message="You may not edit your own wool room!"/>
     <apply block-place="only-iron-renew" block-break="only-iron" region="spawns" message="You may only break iron blocks in spawn!"/>
-    <apply block="deny-beacon" region="wool-rooms" message="You may not break the beacon!"/>
+    <apply block="deny(only-beacon)" region="wool-rooms" message="You may not break the beacon!"/>
     <apply block="deny(void)" region="void-area" message="You may not edit the void!"/>
 </regions>
 <wools craftable="false" wool-proximity-metric="none" monument-proximity-metric="closest block">
     <if variant="default">
-        <wool team="red" color="pink" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
-        <wool team="red" color="purple" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
-        <wool team="blue" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
-        <wool team="blue" color="orange" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
+        <wool team="red-team" color="pink" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
+        <wool team="red-team" color="purple" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
+        <wool team="blue-team" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
+        <wool team="blue-team" color="orange" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
     </if>
     <if variant="halloween">
-        <wool team="red" color="cyan" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
-        <wool team="red" color="blue" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
-        <wool team="blue" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
-        <wool team="blue" color="lime" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
+        <wool team="red-team" color="cyan" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
+        <wool team="red-team" color="blue" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
+        <wool team="blue-team" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
+        <wool team="blue-team" color="lime" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
     </if>
     <if variant="christmas">
-        <wool team="red" color="lime" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
-        <wool team="red" color="cyan" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
-        <wool team="blue" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
-        <wool team="blue" color="orange" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
+        <wool team="red-team" color="lime" monument="red-pink-wool" location="37.5,15.2,-103.5"/>
+        <wool team="red-team" color="cyan" monument="red-purple-wool" location="-36.5,15.2,-103.5"/>
+        <wool team="blue-team" color="yellow" monument="blue-yellow-wool" location="-36.5,15.2,104.5"/>
+        <wool team="blue-team" color="orange" monument="blue-orange-wool" location="37.5,15.2,104.5"/>
     </if>
 </wools>
 <!-- wool spawn stuff -->


### PR DESCRIPTION
- Renamed team ID's from `red` and `blue` to `red-team` and `blue-team` respectively.
- Simplified team ID references by directly mentioning the team’s ID, eliminating the need for prior filter definitions.
- Simplified the `deny-beacon` filter.
- Removed the `only-air` filter as it was defined but not being used anywhere.


And as always, the changes above have been tested on a private local testing server to ensure compatibility.