### PR TITLE
MissingNo: 1.1.5

### DIFF
--- a/dtcm/missingno/map.xml
+++ b/dtcm/missingno/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>MissingNo</name>
-<version>1.1.4</version>
+<version>1.1.5</version>
 <variant id="christmas" world="christmas" override="true">FrostyNo</variant>
 <objective>Destroy the enemy team's obsidian monument!</objective>
 <include id="gapple-kill-reward"/>
@@ -29,7 +29,7 @@
         <chestplate material="leather chestplate" team-color="true" unbreakable="true"/>
         <leggings material="chainmail leggings" enchantment="protection projectile:2" unbreakable="true"/>
         <boots material="leather boots" team-color="true" unbreakable="true"/>
-        <effect duration="2s" amplifier="255">damage resistance</effect>
+        <effect duration="2s" amplifier="5">damage resistance</effect>
     </kit>
 </kits>
 <spawns>
@@ -50,16 +50,12 @@
     </spawn>
 </spawns>
 <filters>
-    <team id="only-blue">blue-team</team>
-    <team id="only-red">red-team</team>
     <all id="only-iron-cause-world">
         <material id="only-iron">iron block</material>
         <cause>world</cause>
     </all>
     <material id="only-air">air</material>
-    <deny id="deny-beacon">
-        <material>beacon</material>
-    </deny>
+    <material id="only-beacon">beacon</material>
 </filters>
 <regions>
     <negative id="void-area">
@@ -86,10 +82,10 @@
     </union>
     <below y="1" id="void-filter-protection"/>
     <!-- applicators -->
-    <apply use="deny-beacon"/>
+    <apply use="deny(only-beacon)"/>
     <apply block-place="only-iron-cause-world" block-break="only-iron" region="spawns" message="You may not edit spawn!"/>
-    <apply enter="only-blue" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-red" region="red-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(red-team)" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="deny(blue-team)" region="red-spawn" message="You may not enter the enemy's spawn!"/>
     <apply block="never" message="You may not edit this area!" region="spawns"/>
     <apply block-place="deny(void)" message="You may not build in the void!" region="void-area"/>
     <apply block="never" region="void-filter-protection"/>
@@ -127,6 +123,7 @@
     <item>wood step</item>
     <item>obsidian</item>
     <item>bucket</item>
+    <item>water bucket</item>
 </itemremove>
 <toolrepair>
     <tool>iron sword</tool>


### PR DESCRIPTION
- Reduced the 255 resistance amplifier to 5 as anything beyond that won't have any extra effects.
- Simplified team ID references by directly mentioning the team’s ID, eliminating the need for prior filter definitions.
- Simplified the deny-beacon filter.
- Added water bucket to itemremove