### PR TITLE
Level Up: Prevent tools and armor from breaking

### DIFF
--- a/ctw/level_up/map.xml
+++ b/ctw/level_up/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Level Up</name>
-<version>1.0.2</version>
+<version>1.0.3</version>
 <objective>Capture the enemy's wool!</objective>
 <created>2025-02-02</created>
 <include id="gapple-kill-reward"/>
@@ -18,22 +18,22 @@
 <kits>
     <kit id="spawn-kit">
         <clear/>
-        <item slot="0" material="iron sword"/>
-        <item slot="1" material="bow"/>
-        <item slot="2" material="iron pickaxe"/>
-        <item slot="3" material="iron axe"/>
+        <item slot="0" material="iron sword" unbreakable="true"/>
+        <item slot="1" material="bow" unbreakable="true"/>
+        <item slot="2" material="iron pickaxe" unbreakable="true"/>
+        <item slot="3" material="iron axe" unbreakable="true"/>
         <item slot="4" material="wood" amount="64"/>
         <item slot="5" material="smooth brick" amount="64"/>
-        <item slot="6" material="iron spade"/>
+        <item slot="6" material="iron spade" unbreakable="true"/>
         <item slot="7" material="water bucket"/>
         <item slot="8" material="golden apple"/>
         <item slot="9" material="ink sack" amount="1" damage="4"/>
         <item slot="28" material="arrow" amount="64"/>
         <item slot="31" material="wood" amount="64"/>
-        <helmet material="leather helmet" team-color="true"/>
-        <chestplate material="leather chestplate" team-color="true"/>
-        <leggings material="chainmail leggings"/>
-        <boots material="leather boots" team-color="true"/>
+        <helmet material="leather helmet" team-color="true" unbreakable="true"/>
+        <chestplate material="leather chestplate" team-color="true" unbreakable="true"/>
+        <leggings material="chainmail leggings" unbreakable="true"/>
+        <boots material="leather boots" team-color="true" unbreakable="true"/>
         <effect duration="5s" amplifier="255">damage resistance</effect>
         <action>
             <set var="player.level" value="1"/>


### PR DESCRIPTION
This commit applies the unbreakable attribute to default tools and armor. When defending, there's instances of players breaking their tools - the intended behavior is that players typically should not be without a pickaxe or other tools being forced to leave or jump in the void.