### PR TITLE
Explosive Vengeance: Fix objective score discrepancy

### DIFF
--- a/tdm/explosive_vengeance/map.xml
+++ b/tdm/explosive_vengeance/map.xml
@@ -1,8 +1,8 @@
 <map proto="1.5.0">
 <name>Explosive Vengeance</name>
-<version>1.1.6</version>
+<version>1.1.7</version>
 <created>2015-06-17</created>
-<objective>Be team with the most amount of kills after 15 minutes or the first team to 200 points!</objective>
+<objective>Be team with the most amount of kills after 15 minutes or the first team to 100 points!</objective>
 <gamemode>tdm</gamemode>
 <gamemode>scorebox</gamemode>
 <authors>


### PR DESCRIPTION
The `<limit>` in the XML is 100 points, which means the match ends at 100 points - however, the objective states that it requires 200. The `<objective>` has been brought down to 100 to reflect this.