### PR TITLE
Happy Rainbow: 2.0.6

### DIFF
--- a/ctf/happy_rainbow/map.xml
+++ b/ctf/happy_rainbow/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <name>Happy Rainbow</name>
 <variant id="rage">Snowball RAGE</variant>
-<version>2.0.5</version>
+<version>2.0.6</version>
 <created>2022-08-15</created>
 <gamemode>ctf</gamemode>
 <include id="void-death"/>
@@ -94,18 +94,6 @@
     <projectile id="heavySnowball" name="Heavy Snowball" projectile="Snowball" damage="9999" throwable="true" click="right"/>
 </projectiles>
 <filters>
-    <not id="not-red">
-        <team id="only-red">red</team>
-    </not>
-    <not id="not-yellow">
-        <team id="only-yellow">yellow</team>
-    </not>
-    <not id="not-green">
-        <team id="only-green">green</team>
-    </not>
-    <not id="not-blue">
-        <team id="only-blue">blue</team>
-    </not>
     <any id="interactable">
         <material>wool</material>
         <material>stained glass:0</material>
@@ -190,10 +178,10 @@
         <cuboid min="-2,3,-1" max="3,4,2"/>
         <cuboid min="-1,3,-2" max="2,4,3"/>
     </union>
-    <apply enter="only-red" region="red-protection" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-yellow" region="yellow-protection" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-green" region="green-protection" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-blue" region="blue-protection" message="You may not enter the enemy's spawn!"/>
+    <apply enter="red" region="red-protection" message="You may not enter the enemy's spawn!"/>
+    <apply enter="yellow" region="yellow-protection" message="You may not enter the enemy's spawn!"/>
+    <apply enter="green" region="green-protection" message="You may not enter the enemy's spawn!"/>
+    <apply enter="blue" region="blue-protection" message="You may not enter the enemy's spawn!"/>
     <apply block="interactable"/>
     <apply block="never"/>
 </regions>
@@ -201,18 +189,18 @@
     <mercy>3</mercy>
 </score>
 <flags>
-    <flag id="red-flag" name="Red Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not-red" post="red-post" shared="true"/>
-    <flag id="yellow-flag" name="Yellow Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not-yellow" post="yellow-post" shared="true"/>
-    <flag id="green-flag" name="Green Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not-green" post="green-post" shared="true"/>
-    <flag id="blue-flag" name="Blue Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not-blue" post="blue-post" shared="true"/>
-    <post id="red-post" owner="red" recover-time="10" respawn-time="10" pickup-filter="not-red" yaw="-135">-24.5,3,25.5</post>
-    <post id="yellow-post" owner="yellow" recover-time="10" respawn-time="10" pickup-filter="not-yellow" yaw="-45">-24.5,3,-24.5</post>
-    <post id="green-post" owner="green" recover-time="10" respawn-time="10" pickup-filter="not-green" yaw="45">25.5,3,-24.5</post>
-    <post id="blue-post" owner="blue" recover-time="10" respawn-time="10" pickup-filter="not-blue" yaw="135">25.5,3,25.5</post>
-    <net region="red-net" flags="yellow-flag green-flag blue-flag" points="1" capture-filter="only-red"/>
-    <net region="yellow-net" flags="red-flag green-flag blue-flag" points="1" capture-filter="only-yellow"/>
-    <net region="green-net" flags="red-flag yellow-flag blue-flag" points="1" capture-filter="only-green"/>
-    <net region="blue-net" flags="red-flag yellow-flag green-flag" points="1" capture-filter="only-blue"/>
+    <flag id="red-flag" name="Red Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not(red)" post="red-post" shared="true"/>
+    <flag id="yellow-flag" name="Yellow Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not(yellow)" post="yellow-post" shared="true"/>
+    <flag id="green-flag" name="Green Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not(green)" post="green-post" shared="true"/>
+    <flag id="blue-flag" name="Blue Flag" carry-message="Capture the enemy flag at your spawn!" pickup-filter="not(blue)" post="blue-post" shared="true"/>
+    <post id="red-post" owner="red" recover-time="10" respawn-time="10" pickup-filter="not(red)" yaw="-135">-24.5,3,25.5</post>
+    <post id="yellow-post" owner="yellow" recover-time="10" respawn-time="10" pickup-filter="not(yellow)" yaw="-45">-24.5,3,-24.5</post>
+    <post id="green-post" owner="green" recover-time="10" respawn-time="10" pickup-filter="not(green)" yaw="45">25.5,3,-24.5</post>
+    <post id="blue-post" owner="blue" recover-time="10" respawn-time="10" pickup-filter="not(blue)" yaw="135">25.5,3,25.5</post>
+    <net region="red-net" flags="yellow-flag green-flag blue-flag" points="1" capture-filter="red"/>
+    <net region="yellow-net" flags="red-flag green-flag blue-flag" points="1" capture-filter="yellow"/>
+    <net region="green-net" flags="red-flag yellow-flag blue-flag" points="1" capture-filter="green"/>
+    <net region="blue-net" flags="red-flag yellow-flag green-flag" points="1" capture-filter="blue"/>
 </flags>
 <kill-rewards>
     <kill-reward>
@@ -240,13 +228,13 @@
         <filter>
             <material>wool</material>
         </filter>
-        <replacement>95:0</replacement>
+        <replacement>stained glass:0</replacement>
     </rule>
 </block-drops>
 <falling-blocks>
     <rule delay="30">
         <filter>
-            <material>95:0</material>
+            <material>stained glass:0</material>
         </filter>
     </rule>
 </falling-blocks>
@@ -256,6 +244,7 @@
     <item>leather leggings</item>
     <item>leather boots</item>
     <item>stone sword</item>
+    <item>diamond sword</item>
 </itemremove>
 <itemkeep>
     <item>golden apple</item>


### PR DESCRIPTION
Contains numerous bug fixes and cleanups:

- ~~The snowball rage variant has been turned into proper rage (duh)~~
  - ~~Heavy snowballs are given as a kill reward instead of regular snowballs~~
  - ~~Added rage module (this enables melee on snowballs and swords to insta-kill)~~
    - I don't know, however, if melee not insta-killing wasn't by any chance intentional. Personally, I like the current state (taking 2-3 hits to kill by melee) a bit more, but it doesn't line up with the expectation of rage being an "insta-kill on hit" gamemode. As such, I'm willing to roll this back if it is intentional.
  - Added diamond swords to itemremove
  - ~~Removed golden apple kill reward~~
- Team filters have been replaced with direct team references
- ~~Removed explicit gamemode tag, relying on PGM's built-in inference (also willing to roll back if desired)~~
- The ID of stained glass has been replaced with the material name for consistency