### PR TITLE
Points Festival: 1.1.5

### DIFF
--- a/mixed/points_festival/map.xml
+++ b/mixed/points_festival/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Points Festival</name>
-<version>1.1.4</version>
+<version>1.1.5</version>
 <objective>Gain the most points!</objective>
 <gamemode>koth</gamemode>
 <created>2023-01-30</created>
@@ -68,11 +68,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-middle-1" player-filter="only-hill-middle-and-0-flag"/>
-        <control-point points="2" name="hill-middle-2" player-filter="only-hill-middle-and-1-flag"/>
-        <control-point points="4" name="hill-middle-4" player-filter="only-hill-middle-and-2-flag"/>
-        <control-point points="8" name="hill-middle-8" player-filter="only-hill-middle-and-3-flag"/>
-        <control-point points="16" name="hill-middle-16" player-filter="only-hill-middle-and-4-flag"/>
+        <control-point points="1" name="hill-middle-1" player-filter="all(flag_count=0, only-hill-middle)"/>
+        <control-point points="2" name="hill-middle-2" player-filter="all(flag_count=1, only-hill-middle)"/>
+        <control-point points="4" name="hill-middle-4" player-filter="all(flag_count=2, only-hill-middle)"/>
+        <control-point points="8" name="hill-middle-8" player-filter="all(flag_count=3, only-hill-middle)"/>
+        <control-point points="16" name="hill-middle-16" player-filter="all(flag_count=4, only-hill-middle)"/>
     </control-points>
     <!-- north hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -83,11 +83,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-north-1" player-filter="only-hill-north-and-0-flag"/>
-        <control-point points="2" name="hill-north-2" player-filter="only-hill-north-and-1-flag"/>
-        <control-point points="4" name="hill-north-4" player-filter="only-hill-north-and-2-flag"/>
-        <control-point points="8" name="hill-north-8" player-filter="only-hill-north-and-3-flag"/>
-        <control-point points="16" name="hill-north-16" player-filter="only-hill-north-and-4-flag"/>
+        <control-point points="1" name="hill-north-1" player-filter="all(flag_count=0, only-hill-north)"/>
+        <control-point points="2" name="hill-north-2" player-filter="all(flag_count=1, only-hill-north)"/>
+        <control-point points="4" name="hill-north-4" player-filter="all(flag_count=2, only-hill-north)"/>
+        <control-point points="8" name="hill-north-8" player-filter="all(flag_count=3, only-hill-north)"/>
+        <control-point points="16" name="hill-north-16" player-filter="all(flag_count=4, only-hill-north)"/>
     </control-points>
     <!-- north-east hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -98,11 +98,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-north-east-1" player-filter="only-hill-north-east-and-0-flag"/>
-        <control-point points="2" name="hill-north-east-2" player-filter="only-hill-north-east-and-1-flag"/>
-        <control-point points="4" name="hill-north-east-4" player-filter="only-hill-north-east-and-2-flag"/>
-        <control-point points="8" name="hill-north-east-8" player-filter="only-hill-north-east-and-3-flag"/>
-        <control-point points="16" name="hill-north-east-16" player-filter="only-hill-north-east-and-4-flag"/>
+        <control-point points="1" name="hill-north-east-1" player-filter="all(flag_count=0, only-hill-north-east)"/>
+        <control-point points="2" name="hill-north-east-2" player-filter="all(flag_count=1, only-hill-north-east)"/>
+        <control-point points="4" name="hill-north-east-4" player-filter="all(flag_count=2, only-hill-north-east)"/>
+        <control-point points="8" name="hill-north-east-8" player-filter="all(flag_count=3, only-hill-north-east)"/>
+        <control-point points="16" name="hill-north-east-16" player-filter="all(flag_count=4, only-hill-north-east)"/>
     </control-points>
     <!-- east hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -113,11 +113,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-east-1" player-filter="only-hill-east-and-0-flag"/>
-        <control-point points="2" name="hill-east-2" player-filter="only-hill-east-and-1-flag"/>
-        <control-point points="4" name="hill-east-4" player-filter="only-hill-east-and-2-flag"/>
-        <control-point points="8" name="hill-east-8" player-filter="only-hill-east-and-3-flag"/>
-        <control-point points="16" name="hill-east-16" player-filter="only-hill-east-and-4-flag"/>
+        <control-point points="1" name="hill-east-1" player-filter="all(flag_count=0, only-hill-east)"/>
+        <control-point points="2" name="hill-east-2" player-filter="all(flag_count=1, only-hill-east)"/>
+        <control-point points="4" name="hill-east-4" player-filter="all(flag_count=2, only-hill-east)"/>
+        <control-point points="8" name="hill-east-8" player-filter="all(flag_count=3, only-hill-east)"/>
+        <control-point points="16" name="hill-east-16" player-filter="all(flag_count=4, only-hill-east)"/>
     </control-points>
     <!-- south-east hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -128,11 +128,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-south-east-1" player-filter="only-hill-south-east-and-0-flag"/>
-        <control-point points="2" name="hill-south-east-2" player-filter="only-hill-south-east-and-1-flag"/>
-        <control-point points="4" name="hill-south-east-4" player-filter="only-hill-south-east-and-2-flag"/>
-        <control-point points="8" name="hill-south-east-8" player-filter="only-hill-south-east-and-3-flag"/>
-        <control-point points="16" name="hill-south-east-16" player-filter="only-hill-south-east-and-4-flag"/>
+        <control-point points="1" name="hill-south-east-1" player-filter="all(flag_count=0, only-hill-south-east)"/>
+        <control-point points="2" name="hill-south-east-2" player-filter="all(flag_count=1, only-hill-south-east)"/>
+        <control-point points="4" name="hill-south-east-4" player-filter="all(flag_count=2, only-hill-south-east)"/>
+        <control-point points="8" name="hill-south-east-8" player-filter="all(flag_count=3, only-hill-south-east)"/>
+        <control-point points="16" name="hill-south-east-16" player-filter="all(flag_count=4, only-hill-south-east)"/>
     </control-points>
     <!-- south hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -143,11 +143,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-south-1" player-filter="only-hill-south-and-0-flag"/>
-        <control-point points="2" name="hill-south-2" player-filter="only-hill-south-and-1-flag"/>
-        <control-point points="4" name="hill-south-4" player-filter="only-hill-south-and-2-flag"/>
-        <control-point points="8" name="hill-south-8" player-filter="only-hill-south-and-3-flag"/>
-        <control-point points="16" name="hill-south-16" player-filter="only-hill-south-and-4-flag"/>
+        <control-point points="1" name="hill-south-1" player-filter="all(flag_count=0, only-hill-south)"/>
+        <control-point points="2" name="hill-south-2" player-filter="all(flag_count=1, only-hill-south)"/>
+        <control-point points="4" name="hill-south-4" player-filter="all(flag_count=2, only-hill-south)"/>
+        <control-point points="8" name="hill-south-8" player-filter="all(flag_count=3, only-hill-south)"/>
+        <control-point points="16" name="hill-south-16" player-filter="all(flag_count=4, only-hill-south)"/>
     </control-points>
     <!-- south-west hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -158,11 +158,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-south-west-1" player-filter="only-hill-south-west-and-0-flag"/>
-        <control-point points="2" name="hill-south-west-2" player-filter="only-hill-south-west-and-1-flag"/>
-        <control-point points="4" name="hill-south-west-4" player-filter="only-hill-south-west-and-2-flag"/>
-        <control-point points="8" name="hill-south-west-8" player-filter="only-hill-south-west-and-3-flag"/>
-        <control-point points="16" name="hill-south-west-16" player-filter="only-hill-south-west-and-4-flag"/>
+        <control-point points="1" name="hill-south-west-1" player-filter="all(flag_count=0, only-hill-south-west)"/>
+        <control-point points="2" name="hill-south-west-2" player-filter="all(flag_count=1, only-hill-south-west)"/>
+        <control-point points="4" name="hill-south-west-4" player-filter="all(flag_count=2, only-hill-south-west)"/>
+        <control-point points="8" name="hill-south-west-8" player-filter="all(flag_count=3, only-hill-south-west)"/>
+        <control-point points="16" name="hill-south-west-16" player-filter="all(flag_count=4, only-hill-south-west)"/>
     </control-points>
     <!-- west hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -173,11 +173,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-west-1" player-filter="only-hill-west-and-0-flag"/>
-        <control-point points="2" name="hill-west-2" player-filter="only-hill-west-and-1-flag"/>
-        <control-point points="4" name="hill-west-4" player-filter="only-hill-west-and-2-flag"/>
-        <control-point points="8" name="hill-west-8" player-filter="only-hill-west-and-3-flag"/>
-        <control-point points="16" name="hill-west-16" player-filter="only-hill-west-and-4-flag"/>
+        <control-point points="1" name="hill-west-1" player-filter="all(flag_count=0, only-hill-west)"/>
+        <control-point points="2" name="hill-west-2" player-filter="all(flag_count=1, only-hill-west)"/>
+        <control-point points="4" name="hill-west-4" player-filter="all(flag_count=2, only-hill-west)"/>
+        <control-point points="8" name="hill-west-8" player-filter="all(flag_count=3, only-hill-west)"/>
+        <control-point points="16" name="hill-west-16" player-filter="all(flag_count=4, only-hill-west)"/>
     </control-points>
     <!-- north-west hill -->
     <control-points points="0" required="false" capture-time="2.5s" visual-materials="only-wool">
@@ -188,11 +188,11 @@
         </control-point>
     </control-points>
     <control-points show="false" required="false" neutral-state="true" capture-time="0s" owned-decay-rate="10000" capture="everywhere">
-        <control-point points="1" name="hill-north-west-1" player-filter="only-hill-north-west-and-0-flag"/>
-        <control-point points="2" name="hill-north-west-2" player-filter="only-hill-north-west-and-1-flag"/>
-        <control-point points="4" name="hill-north-west-4" player-filter="only-hill-north-west-and-2-flag"/>
-        <control-point points="8" name="hill-north-west-8" player-filter="only-hill-north-west-and-3-flag"/>
-        <control-point points="16" name="hill-north-west-16" player-filter="only-hill-north-west-and-4-flag"/>
+        <control-point points="1" name="hill-north-west-1" player-filter="all(flag_count=0, only-hill-north-west)"/>
+        <control-point points="2" name="hill-north-west-2" player-filter="all(flag_count=1, only-hill-north-west)"/>
+        <control-point points="4" name="hill-north-west-4" player-filter="all(flag_count=2, only-hill-north-west)"/>
+        <control-point points="8" name="hill-north-west-8" player-filter="all(flag_count=3, only-hill-north-west)"/>
+        <control-point points="16" name="hill-north-west-16" player-filter="all(flag_count=4, only-hill-north-west)"/>
     </control-points>
 </control-points>
 <flags name="Boost x2" color="white" shared="true" pickup-kit="flag-kit" drop-kit="flag-kit" show="false" carry-message="Boosting team points x2" carry-kit="carry-kit">
@@ -209,1274 +209,123 @@
 		<post recover-time="5s">11.5,5,-15.5</post>
     </flag>
 </flags>
+<constants>
+    <!-- Packs the flag amount into an inline tuple of 4 octal numerals. This needs to be appropriately shifted if more than 7 flags appear. -->
+    <constant id="packed-flags">(blue_flags * 2^9) + (red_flags * 2^6) + (green_flags * 2^3) + yellow_flags</constant>
+</constants>
 <variables>
     <variable id="flag_count" scope="team"/>
     <variable id="needs_flag_count_update" scope="match"/>
     <variable id="clock_var" scope="match"/>
+    <with-team id="blue_flags" team="blue-team" var="flag_count"/>
+    <with-team id="red_flags" team="red-team" var="flag_count"/>
+    <with-team id="green_flags" team="green-team" var="flag_count"/>
+    <with-team id="yellow_flags" team="yellow-team" var="flag_count"/>
 </variables>
+<replacements>
+    <switch id="flag-state" value="${packed-flags}" scope="match">
+        <case match="1" result="`eYellow `fx2"/>
+        <case match="2" result="`eYellow `fx4"/>
+        <case match="3" result="`eYellow `fx8"/>
+        <case match="4" result="`eYellow `fx16"/>
+        <case match="8" result="`aGreen `fx2"/>
+        <case match="9" result="`aGreen `fx2 | `eYellow `fx2"/>
+        <case match="10" result="`aGreen `fx2 | `eYellow `fx4"/>
+        <case match="11" result="`aGreen `fx2 | `eYellow `fx8"/>
+        <case match="16" result="`aGreen `fx4"/>
+        <case match="17" result="`aGreen `fx4 | `eYellow `fx2"/>
+        <case match="18" result="`aGreen `fx4 | `eYellow `fx4"/>
+        <case match="24" result="`aGreen `fx8"/>
+        <case match="25" result="`aGreen `fx8 | `eYellow `fx2"/>
+        <case match="32" result="`aGreen `fx16"/>
+        <case match="64" result="`cRed `fx2"/>
+        <case match="65" result="`cRed `fx2 | `eYellow `fx2"/>
+        <case match="66" result="`cRed `fx2 | `eYellow `fx4"/>
+        <case match="67" result="`cRed `fx2 | `eYellow `fx8"/>
+        <case match="72" result="`cRed `fx2 | `aGreen `fx2"/>
+        <case match="73" result="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
+        <case match="74" result="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
+        <case match="80" result="`cRed `fx2 | `aGreen `fx4"/>
+        <case match="81" result="`cRed `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
+        <case match="88" result="`cRed `fx2 | `aGreen `fx8"/>
+        <case match="128" result="`cRed `fx4"/>
+        <case match="129" result="`cRed `fx4 | `eYellow `fx2"/>
+        <case match="130" result="`cRed `fx4 | `eYellow `fx4"/>
+        <case match="136" result="`cRed `fx4 | `aGreen `fx2"/>
+        <case match="137" result="`cRed `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
+        <case match="144" result="`cRed `fx4 | `aGreen `fx4"/>
+        <case match="192" result="`cRed `fx8"/>
+        <case match="193" result="`cRed `fx8 | `eYellow `fx2"/>
+        <case match="200" result="`cRed `fx8 | `aGreen `fx2"/>
+        <case match="256" result="`cRed `fx16"/>
+        <case match="512" result="`9Blue `fx2"/>
+        <case match="513" result="`9Blue `fx2 | `eYellow `fx2"/>
+        <case match="514" result="`9Blue `fx2 | `eYellow `fx4"/>
+        <case match="515" result="`9Blue `fx2 | `eYellow `fx8"/>
+        <case match="520" result="`9Blue `fx2 | `aGreen `fx2"/>
+        <case match="521" result="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
+        <case match="522" result="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
+        <case match="528" result="`9Blue `fx2 | `aGreen `fx4"/>
+        <case match="529" result="`9Blue `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
+        <case match="536" result="`9Blue `fx2 | `aGreen `fx8"/>
+        <case match="576" result="`9Blue `fx2 | `cRed `fx2"/>
+        <case match="577" result="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx2"/>
+        <case match="578" result="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx4"/>
+        <case match="584" result="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2"/>
+        <case match="585" result="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
+        <case match="592" result="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx4"/>
+        <case match="640" result="`9Blue `fx2 | `cRed `fx4"/>
+        <case match="641" result="`9Blue `fx2 | `cRed `fx4 | `eYellow `fx2"/>
+        <case match="648" result="`9Blue `fx2 | `cRed `fx4 | `aGreen `fx2"/>
+        <case match="704" result="`9Blue `fx2 | `cRed `fx8"/>
+        <case match="1024" result="`9Blue `fx4"/>
+        <case match="1025" result="`9Blue `fx4 | `eYellow `fx2"/>
+        <case match="1026" result="`9Blue `fx4 | `eYellow `fx4"/>
+        <case match="1032" result="`9Blue `fx4 | `aGreen `fx2"/>
+        <case match="1033" result="`9Blue `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
+        <case match="1040" result="`9Blue `fx4 | `aGreen `fx4"/>
+        <case match="1088" result="`9Blue `fx4 | `cRed `fx2"/>
+        <case match="1089" result="`9Blue `fx4 | `cRed `fx2 | `eYellow `fx2"/>
+        <case match="1096" result="`9Blue `fx4 | `cRed `fx2 | `aGreen `fx2"/>
+        <case match="1152" result="`9Blue `fx4 | `cRed `fx4"/>
+        <case match="1536" result="`9Blue `fx8"/>
+        <case match="1537" result="`9Blue `fx8 | `eYellow `fx2"/>
+        <case match="1544" result="`9Blue `fx8 | `aGreen `fx2"/>
+        <case match="1600" result="`9Blue `fx8 | `cRed `fx2"/>
+        <case match="2048" result="`9Blue `fx16"/>
+        <fallback>`cInvalid state, please file a bug report</fallback>
+    </switch>
+</replacements>
 <actions>
     <!-- chat messages for players carrying a flag -->
     <action id="set-chat-message-for-flag-carriers" filter="carrying-any-flag" scope="player">
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message text="`eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-4-flag">
-                        <message text="`eYellow `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message text="`aGreen `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`aGreen `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`aGreen `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-4-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`aGreen `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`cRed `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message text="`cRed `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx2 | `aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`cRed `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx4 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`cRed `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx8 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-4-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`cRed `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`9Blue `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message text="`9Blue `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx2 | `cRed `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message text="`9Blue `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx4 | `cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4 | `cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx4 | `cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message text="`9Blue `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx8 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue `fx8 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-4-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message text="`9Blue x16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
+        <message text="{state}">
+            <replacements>
+                <replacement id="state">flag-state</replacement>
+            </replacements>
+        </message>
     </action>
     <!-- action bar messages -->
-    <action id="set-action-bar-message" filter="not-carrying-any-flag-and-alive" scope="player">
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message actionbar="`eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-4-flag">
-                        <message actionbar="`eYellow `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message actionbar="`aGreen `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`aGreen `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`aGreen `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-4-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`aGreen `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`cRed `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message actionbar="`cRed `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx2 | `aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`cRed `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx4 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`cRed `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx8 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-0-flag">
-            <action filter="red-team-4-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`cRed `fx16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`9Blue `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-3-flag">
-                        <message actionbar="`9Blue `fx2 | `eYellow `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-3-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `aGreen `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx2 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-1-flag">
-            <action filter="red-team-3-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx2 | `cRed `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx4 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-2-flag">
-                        <message actionbar="`9Blue `fx4 | `eYellow `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx4 | `aGreen `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-2-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4 | `aGreen `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx4 | `cRed `fx2 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4 | `cRed `fx2 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-2-flag">
-            <action filter="red-team-2-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx4 | `cRed `fx4"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx8"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-1-flag">
-                        <message actionbar="`9Blue `fx8 | `eYellow `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-1-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx8 | `aGreen `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-3-flag">
-            <action filter="red-team-1-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue `fx8 | `cRed `fx2"/>
-                    </action>
-                </action>
-            </action>
-        </action>
-        <action filter="blue-team-4-flag">
-            <action filter="red-team-0-flag">
-                <action filter="green-team-0-flag">
-                    <action filter="yellow-team-0-flag">
-                        <message actionbar="`9Blue x16"/>
-                    </action>
-                </action>
-            </action>
-        </action>
+    <action id="set-action-bar-message" filter="all(all(not(carrying-any-flag), any(alive, observing)), any(blue_flags=1.., red_flags=1.., green_flags=1.., yellow_flags=1..))" scope="player">
+        <message actionbar="{state}">
+            <replacements>
+                <replacement id="state">flag-state</replacement>
+            </replacements>
+        </message>
     </action>
-    <!-- mega boots titles -->
+    <!-- mega boost titles -->
     <action id="mega-boost-titles" scope="match">
-        <action filter="blue-team-4-flag">
-            <message fade-in="0s" stay="2s" fade-out="0.5s" title="`l`9Blue `fx16"/>
-        </action>
-        <action filter="red-team-4-flag">
-            <message fade-in="0s" stay="2s" fade-out="0.5s" title="`l`cRed `fx16"/>
-        </action>
-        <action filter="green-team-4-flag">
-            <message fade-in="0s" stay="2s" fade-out="0.5s" title="`l`aGreen `fx16"/>
-        </action>
-        <action filter="yellow-team-4-flag">
-            <message fade-in="0s" stay="2s" fade-out="0.5s" title="`l`eYellow `fx16"/>
-        </action>
+        <message fade-in="0s" stay="2s" fade-out="0.5s" title="{who} `fx16">
+            <replacements>
+                <switch id="who" value="${packed-flags}">
+                    <case match="4" result="`l`eYellow"/>
+                    <case match="32" result="`l`aGreen"/>
+                    <case match="256" result="`l`cRed"/>
+                    <case match="2048" result="`l`9Blue"/>
+                    <fallback>`cInvalid state, please file a bug report</fallback>
+                </switch>
+            </replacements>
+        </message>
     </action>
     <!-- flag counter -->
     <action id="update-flag-count" scope="match">
@@ -1489,13 +338,13 @@
         <set var="needs_flag_count_update" value="0"/>
     </action>
     <!-- trigger -->
-    <trigger filter="needs_flag_count_update-filter-1" action="update-flag-count" scope="match"/>
-    <trigger filter="trigger-forzen-flag-count-filter" action="update-flag-count" scope="match"/> <!-- fix for stuck flag counter action -->
-    <trigger filter="needs_flag_count_update-filter-0" action="set-chat-message-for-flag-carriers" scope="player"/>
-    <trigger filter="any-team-4-flag" action="mega-boost-titles" scope="match"/>
+    <trigger filter="needs_flag_count_update=1" action="update-flag-count" scope="match"/>
+    <trigger filter="trigger-frozen-flag-count-filter" action="update-flag-count" scope="match"/> <!-- fix for stuck flag counter action -->
+    <trigger filter="needs_flag_count_update=0" action="set-chat-message-for-flag-carriers" scope="player"/>
+    <trigger filter="any(blue_flags=4, red_flags=4, green_flags=4, yellow_flags=4)" action="mega-boost-titles" scope="match"/>
     <trigger filter="clock_var-0-after-1s" scope="match">
         <action>
-            <switch-scope inner="player">
+            <switch-scope inner="player" observers="true">
                 <action id="set-action-bar-message"/>
             </switch-scope>
             <set var="clock_var" value="1"/>
@@ -1503,7 +352,7 @@
     </trigger>
     <trigger filter="clock_var-1-after-1s" scope="match">
         <action>
-            <switch-scope inner="player">
+            <switch-scope inner="player" observers="true">
                 <action id="set-action-bar-message"/>
             </switch-scope>
             <set var="clock_var" value="0"/>
@@ -1511,269 +360,27 @@
     </trigger>
 </actions>
 <filters>
-	<material id="only-wool">wool</material>
-    <after id="clock_var-0-after-1s" duration="1s">
-        <variable var="clock_var">0</variable>
-    </after>
-    <after id="clock_var-1-after-1s" duration="1s">
-        <variable var="clock_var">1</variable>
-    </after>
+    <material id="only-wool">wool</material>
+    <after id="clock_var-0-after-1s" duration="1s" filter="clock_var=0"/>
+    <after id="clock_var-1-after-1s" duration="1s" filter="clock_var=1"/>
     <!-- filters for action bar message -->
-    <any id="any-team-any-flag">
-        <variable id="blue-team-0-flag" team="blue-team" var="flag_count">0</variable>
-        <variable id="blue-team-1-flag" team="blue-team" var="flag_count">1</variable>
-        <variable id="blue-team-2-flag" team="blue-team" var="flag_count">2</variable>
-        <variable id="blue-team-3-flag" team="blue-team" var="flag_count">3</variable>
-        <variable id="blue-team-4-flag" team="blue-team" var="flag_count">4</variable>
-        <variable id="red-team-0-flag" team="red-team" var="flag_count">0</variable>
-        <variable id="red-team-1-flag" team="red-team" var="flag_count">1</variable>
-        <variable id="red-team-2-flag" team="red-team" var="flag_count">2</variable>
-        <variable id="red-team-3-flag" team="red-team" var="flag_count">3</variable>
-        <variable id="red-team-4-flag" team="red-team" var="flag_count">4</variable>
-        <variable id="green-team-0-flag" team="green-team" var="flag_count">0</variable>
-        <variable id="green-team-1-flag" team="green-team" var="flag_count">1</variable>
-        <variable id="green-team-2-flag" team="green-team" var="flag_count">2</variable>
-        <variable id="green-team-3-flag" team="green-team" var="flag_count">3</variable>
-        <variable id="green-team-4-flag" team="green-team" var="flag_count">4</variable>
-        <variable id="yellow-team-0-flag" team="yellow-team" var="flag_count">0</variable>
-        <variable id="yellow-team-1-flag" team="yellow-team" var="flag_count">1</variable>
-        <variable id="yellow-team-2-flag" team="yellow-team" var="flag_count">2</variable>
-        <variable id="yellow-team-3-flag" team="yellow-team" var="flag_count">3</variable>
-        <variable id="yellow-team-4-flag" team="yellow-team" var="flag_count">4</variable>
+    <any id="carrying-any-flag">
+        <carrying-flag>flag-1</carrying-flag>
+        <carrying-flag>flag-2</carrying-flag>
+        <carrying-flag>flag-3</carrying-flag>
+        <carrying-flag>flag-4</carrying-flag>
     </any>
-    <any id="any-team-4-flag">
-        <variable team="blue-team" var="flag_count">4</variable>
-        <variable team="red-team" var="flag_count">4</variable>
-        <variable team="green-team" var="flag_count">4</variable>
-        <variable team="yellow-team" var="flag_count">4</variable>
-    </any>
-    <team id="only-blue">blue-team</team>
-    <team id="only-red">red-team</team>
-    <team id="only-green">green-team</team>
-    <team id="only-yellow">yellow-team</team>
-    <all id="not-carrying-any-flag-and-alive">
-        <filter id="not-carrying-any-flag"/>
-        <any>
-            <alive id="only-alive"/>
-            <observing/>
-        </any>
-    </all>
-    <not id="not-carrying-any-flag">
-        <any id="carrying-any-flag">
-            <carrying-flag>flag-1</carrying-flag>
-            <carrying-flag>flag-2</carrying-flag>
-            <carrying-flag>flag-3</carrying-flag>
-            <carrying-flag>flag-4</carrying-flag>
-        </any>
-    </not>
-    <after id="trigger-forzen-flag-count-filter" duration="3s">
-        <variable var="needs_flag_count_update">1</variable>
-    </after>
-    <variable id="needs_flag_count_update-filter-1" var="needs_flag_count_update">1</variable>
-    <variable id="needs_flag_count_update-filter-0" var="needs_flag_count_update">0</variable>
-    <variable id="carrying-0-flag" var="flag_count">0</variable>
-    <variable id="carrying-1-flag" var="flag_count">1</variable>
-    <variable id="carrying-2-flag" var="flag_count">2</variable>
-    <variable id="carrying-3-flag" var="flag_count">3</variable>
-    <variable id="carrying-4-flag" var="flag_count">4</variable>
-    <!-- middle hill filters -->
-    <objective id="only-hill-middle">hill-middle</objective>
-    <all id="only-hill-middle-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-middle"/>
-    </all>
-    <all id="only-hill-middle-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-middle"/>
-    </all>
-    <all id="only-hill-middle-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-middle"/>
-    </all>
-    <all id="only-hill-middle-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-middle"/>
-    </all>
-    <all id="only-hill-middle-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-middle"/>
-    </all>
-    <!-- north hill filters -->
-    <objective id="only-hill-north">hill-north</objective>
-    <all id="only-hill-north-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-north"/>
-    </all>
-    <all id="only-hill-north-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-north"/>
-    </all>
-    <all id="only-hill-north-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-north"/>
-    </all>
-    <all id="only-hill-north-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-north"/>
-    </all>
-    <all id="only-hill-north-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-north"/>
-    </all>
-    <!-- east hill filters -->
-    <objective id="only-hill-east">hill-east</objective>
-    <all id="only-hill-east-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-east"/>
-    </all>
-    <all id="only-hill-east-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-east"/>
-    </all>
-    <all id="only-hill-east-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-east"/>
-    </all>
-    <all id="only-hill-east-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-east"/>
-    </all>
-    <all id="only-hill-east-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-east"/>
-    </all>
-    <!-- south hill filters -->
-    <objective id="only-hill-south">hill-south</objective>
-    <all id="only-hill-south-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-south"/>
-    </all>
-    <all id="only-hill-south-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-south"/>
-    </all>
-    <all id="only-hill-south-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-south"/>
-    </all>
-    <all id="only-hill-south-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-south"/>
-    </all>
-    <all id="only-hill-south-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-south"/>
-    </all>
-    <!-- west hill filters -->
-    <objective id="only-hill-west">hill-west</objective>
-    <all id="only-hill-west-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-west"/>
-    </all>
-    <all id="only-hill-west-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-west"/>
-    </all>
-    <all id="only-hill-west-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-west"/>
-    </all>
-    <all id="only-hill-west-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-west"/>
-    </all>
-    <all id="only-hill-west-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-west"/>
-    </all>
-    <!-- north-east hill filters -->
-    <objective id="only-hill-north-east">hill-north-east</objective>
-    <all id="only-hill-north-east-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-north-east"/>
-    </all>
-    <all id="only-hill-north-east-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-north-east"/>
-    </all>
-    <all id="only-hill-north-east-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-north-east"/>
-    </all>
-    <all id="only-hill-north-east-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-north-east"/>
-    </all>
-    <all id="only-hill-north-east-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-north-east"/>
-    </all>
-    <!-- south-east hill filters -->
-    <objective id="only-hill-south-east">hill-south-east</objective>
-    <all id="only-hill-south-east-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-south-east"/>
-    </all>
-    <all id="only-hill-south-east-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-south-east"/>
-    </all>
-    <all id="only-hill-south-east-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-south-east"/>
-    </all>
-    <all id="only-hill-south-east-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-south-east"/>
-    </all>
-    <all id="only-hill-south-east-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-south-east"/>
-    </all>
-    <!-- south-west hill filters -->
-    <objective id="only-hill-south-west">hill-south-west</objective>
-    <all id="only-hill-south-west-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-south-west"/>
-    </all>
-    <all id="only-hill-south-west-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-south-west"/>
-    </all>
-    <all id="only-hill-south-west-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-south-west"/>
-    </all>
-    <all id="only-hill-south-west-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-south-west"/>
-    </all>
-    <all id="only-hill-south-west-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-south-west"/>
-    </all>
-    <!-- north-west hill filters -->
-    <objective id="only-hill-north-west">hill-north-west</objective>
-    <all id="only-hill-north-west-and-0-flag">
-        <filter id="carrying-0-flag"/>
-        <filter id="only-hill-north-west"/>
-    </all>
-    <all id="only-hill-north-west-and-1-flag">
-        <filter id="carrying-1-flag"/>
-        <filter id="only-hill-north-west"/>
-    </all>
-    <all id="only-hill-north-west-and-2-flag">
-        <filter id="carrying-2-flag"/>
-        <filter id="only-hill-north-west"/>
-    </all>
-    <all id="only-hill-north-west-and-3-flag">
-        <filter id="carrying-3-flag"/>
-        <filter id="only-hill-north-west"/>
-    </all>
-    <all id="only-hill-north-west-and-4-flag">
-        <filter id="carrying-4-flag"/>
-        <filter id="only-hill-north-west"/>
-    </all>
+    <after id="trigger-frozen-flag-count-filter" duration="3s" filter="needs_flag_count_update=1"/>
+    <!-- hill filters -->
+    <captured id="only-hill-middle">hill-middle</captured>
+    <captured id="only-hill-north">hill-north</captured>
+    <captured id="only-hill-east">hill-east</captured>
+    <captured id="only-hill-south">hill-south</captured>
+    <captured id="only-hill-west">hill-west</captured>
+    <captured id="only-hill-north-east">hill-north-east</captured>
+    <captured id="only-hill-south-east">hill-south-east</captured>
+    <captured id="only-hill-south-west">hill-south-west</captured>
+    <captured id="only-hill-north-west">hill-north-west</captured>
 </filters>
 <regions>
     <cylinder id="blue-spawn-point" base="3,7,-3" radius="1" height="0"/>
@@ -1791,11 +398,11 @@
     </negative>
     <!-- applicators -->
     <apply block="never" region="everywhere" message="You may not edit the map!"/>
-    <apply enter="not-carrying-any-flag" region="spawns" message="You may not enter spawn carrying a flag!"/>
-    <apply enter="only-blue" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-red" region="red-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-green" region="green-spawn" message="You may not enter the enemy's spawn!"/>
-    <apply enter="only-yellow" region="yellow-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="not(carrying-any-flag)" region="spawns" message="You may not enter spawn carrying a flag!"/>
+    <apply enter="blue-team" region="blue-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="red-team" region="red-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="green-team" region="green-spawn" message="You may not enter the enemy's spawn!"/>
+    <apply enter="yellow-team" region="yellow-spawn" message="You may not enter the enemy's spawn!"/>
     <apply kit="reset-resistance-kit" region="not-spawns"/>
 </regions>
 <toolrepair>


### PR DESCRIPTION
- Drastically reduces line count (by approximately 76 %)
  - Achieved using inline filters and the newly added switch replacement (https://github.com/PGMDev/PGM/commit/66a49eaee7c94a5558763d3b9b07df5035405e55)
- Lets observers see the flag multiplier state again
- Deprecated `<objective>` filters have been replaced with `<captured>` filters