### PR TITLE
fix(cirrus_park): remove effects on manual flag drop

### DIFF
--- a/kotf/cirrus_park/map.xml
+++ b/kotf/cirrus_park/map.xml
@@ -1,8 +1,10 @@
 <map proto="1.5.0" min-server-version="1.21.8">
 <name>Cirrus Park</name>
 <created>2025-08-04</created>
-<version>1.0</version>
+<version>1.0.1</version>
 <objective>Control the flag and reach 300 points to win!</objective>
+<gamemode>kotf</gamemode>
+<gamemode>tdm</gamemode>
 <include id="gapple-kill-reward"/>
 <include id="void-death"/>
 <authors>
@@ -71,6 +73,8 @@
     </kit>
     <kit id="flag-kit" force="true">
         <max-health>14</max-health>
+    </kit>
+    <kit id="flag-effects">
         <effect>slowness</effect>
         <effect>glowing</effect>
     </kit>
@@ -94,12 +98,12 @@
     </any>
 </filters>
 <flags>
-    <flag id="red-flag" name="Red Flag" color="red" pickup-filter="blue-team" shared="false" points-rate="1" pickup-kit="flag-kit" drop-kit="reset-health" flag-proximity-metric="none">
+    <flag id="red-flag" name="Red Flag" color="red" pickup-filter="blue-team" shared="false" points-rate="1" pickup-kit="flag-kit" drop-kit="reset-health" carry-kit="flag-effects" flag-proximity-metric="none">
         <post return-time="0s" respawn-time="10s">
             <post name="Red Post" yaw="180">0.5,7,26.5</post>
         </post>
     </flag>
-    <flag id="blue-flag" name="Blue Flag" color="blue" pickup-filter="red-team" shared="false" points-rate="1" pickup-kit="flag-kit" drop-kit="reset-health" flag-proximity-metric="none">
+    <flag id="blue-flag" name="Blue Flag" color="blue" pickup-filter="red-team" shared="false" points-rate="1" pickup-kit="flag-kit" drop-kit="reset-health" carry-kit="flag-effects" flag-proximity-metric="none">
         <post return-time="0s" respawn-time="10s">
             <post name="Blue Post" yaw="0">0.5,7,-25.5</post>
         </post>
@@ -107,10 +111,10 @@
 </flags>
 <actions>
     <action id="shield-remover" scope="player" expose="true">
-            <replace-item ignore-metadata="true">
-                <find material="shield"/>
-                <replace material="air"/>
-            </replace-item>      
+        <replace-item ignore-metadata="true">
+            <find material="shield"/>
+            <replace material="air"/>
+        </replace-item>
     </action>
     <trigger filter="carrying" action="shield-remover" scope="player"/>
 </actions>


### PR DESCRIPTION
Removes the slowness + glowing effects from the player when they drop
the flag manually as there's no need to penalize them further when they
don't have the flag anymore.

Additionally, an explicit gamemode designation has been added (PGM
inferred this map to be a TDM+CTF map), and small indentation fixes have
been done.
