### PR TITLE
fix(grand_tournament): make diagonal bridge truly diagonal

### DIFF
--- a/arcade/standard/the_grand_dueling_tournament_ii/map.xml
+++ b/arcade/standard/the_grand_dueling_tournament_ii/map.xml
@@ -17,7 +17,7 @@
                                         \/
 -->
 <name>The Grand Dueling Tournament II</name>
-<version>3.0.3</version>
+<version>3.0.4</version>
 <objective>Defeat opposing teams in The Grand ${tournament-type} Tournament!</objective>
 <phase>staging</phase>
 <variant id="default" world="duel"/>
@@ -1264,7 +1264,7 @@
                     <cuboid min="249,9,-11" size="1,1,7"/>
                     <cuboid min="248,9,-5" size="1,1,4"/>
                 </union>
-                <mirror origin="248.5,9,-1.5" normal="-1,0,1">
+                <mirror origin="248.5,9,-1.5" normal="-1,0,0">
                     <mirror region="arena-1-side-1-bridge-diagonal" origin="248.5,9,-1.5" normal="0,0,1"/>
                 </mirror>
             </union>


### PR DESCRIPTION
Fixes an issue with incorrect mirroring of the diagonal bridge, building the bridge correctly on one side, but not the other.

![image](https://github.com/user-attachments/assets/854bc6f6-94a8-4c7b-b53d-162ff30ed488)
