### PR TITLE
Data-Rush 1.1.2 (Hotfix)

### DIFF
--- a/ctf/tvt_data_rush/map.xml
+++ b/ctf/tvt_data_rush/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0" game="Flag Assault &amp; Blitz">
 <name>TVT: Data Rush</name>
-<version>1.1.1</version>
+<version>1.1.2</version>
 <phase>development</phase>
 <objective>Score your flag in the enemy goals, last team standing wins!</objective>
 <created>2025-11-15</created>
@@ -409,7 +409,7 @@
         <action>
             <set var="player_identifier" value="1"/>
             <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="green_team_lives := green_team_lives + (${score-multiplier} * ${score-amount})"/>
+                <action id="green_team_lives := green_team_lives - (${score-multiplier} * ${score-amount})"/>
                 <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
                 <switch-scope inner="match">
                     <message text="${score-message-double} ${green-team-alias}">
@@ -437,7 +437,7 @@
         <action>
             <set var="player_identifier" value="1"/>
             <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="blue_team_lives := blue_team_lives + (${score-multiplier} * ${score-amount})"/>
+                <action id="blue_team_lives := blue_team_lives - (${score-multiplier} * ${score-amount})"/>
                 <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
                 <switch-scope inner="match">
                     <message text="${score-message-double} ${blue-team-alias}">


### PR DESCRIPTION
- Fixed a bug in the scoring code that made scoring flags in sudden death against specific teams add lives instead of removing them