### PR TITLE
Data Rush 1.2.0

### DIFF
--- a/ctf/tvt_data_rush/map.xml
+++ b/ctf/tvt_data_rush/map.xml
@@ -1,5 +1,6 @@
 <map proto="1.5.0" game="Flag Battles">
 <name>FB: Data-Rush</name>
+<slug>tvt_data_rush</slug>
 <variant id="comp" override="true">FB: Super-Rush</variant>
 <version>1.2.0</version>
 <phase>development</phase>


### PR DESCRIPTION
# Changes
In it's current iteration the mode is a very sit around & watch experience which would be fine for a competitive map but makes it quite annoying for causal games. Now with this version teams get more of the action while still retaining the blitz aspects of the map

- Renamed game mode from Team vs Team to Flag Battles (FB) which better matches with player expectations
- Added a casual mode that redistribute players evenly to other teams when theirs dies ensuring all players get to experience the full match
- Added team detectors that remove teams who have no players for over 15s during a match
- Further cleaned up logic in case in future I turn this mode into an include