### PR TITLE
Data-Rush 1.2.2

### DIFF
--- a/ctf/tvt_data_rush/map.xml
+++ b/ctf/tvt_data_rush/map.xml
@@ -2,12 +2,15 @@
 <name>FB: Data-Rush</name>
 <slug>tvt_data_rush</slug>
 <variant id="comp" override="true">FB: Super-Rush</variant>
-<version>1.2.1</version>
+<version>1.2.2</version>
 <phase>development</phase>
 <objective>Score your flag in the enemy goals, last team standing wins!</objective>
 <created>2025-11-15</created>
 <gamemode>ctf</gamemode>
 <modifybowprojectile pickup-filter="never"/>
+<gamerules>
+    <doFireTick>false</doFireTick>
+</gamerules>
 <include id="gapple-kill-reward"/>
 <constants> 
     
@@ -17,7 +20,7 @@
     <constant id="sudden-death-timelimit">240</constant> <!-- How long the match should last before entering sudden death (seconds) --> <!-- default = 240 (4m) -->
     <constant id="starting-score">6</constant> <!-- Starting hearts for each team -->
     <constant id="score-amount">1</constant> <!-- Team damage dealt for sucessful scores -->
-    <constant id="score-multiplier">2</constant> <!-- Multiplies the damage dealt by score-ammount when scoring flags during sudden death -->
+    
     <if variant="comp">
         <constant id="kill-teams">1</constant> <!-- When teams are killed and this feature is enabled players are sent to obs instead of swapping teams (Used primarily for comp) -->
     </if>
@@ -36,9 +39,8 @@
     <constant id="green-team-alias">`aGreen Team</constant> 
     <constant id="blue-team-alias">`9Blue Team</constant> 
     <constant id="dead-team-alias">-----</constant> 
-    <constant id="score-message">{player} dealt `d`l1 `rdamage to</constant> <!-- Message for when players deal regular damage to teams -->
-    <constant id="score-message-double">{player} dealt `5`l2 `rdamage to</constant> <!-- Message for when players deal double damage to teams -->
-
+    <constant id="score-message">{player} dealt `d`l{calcdamage} `rdamage to</constant> <!-- Message for when players deal damage to teams -->
+   
     <!-- Internal -->
     <constant id="no-players">999</constant> 
     <constant id="no-message">0</constant> 
@@ -61,7 +63,7 @@
 </rules>
 <broadcasts>
     <tip after="1s" every="3m">Scoring flags in enemy goals will reduce their lives!</tip>
-    <tip after="90s" every="3m">TNT and other supplies can be found in loot chests!</tip>
+    <tip after="90s" every="3m">Explosives and other supplies can be found in loot chests!</tip>
 </broadcasts>
 <stats>
     <stat name="`6Most damage dealt to enemy teams" value="team_damage_dealt_tracker"/>
@@ -83,7 +85,6 @@
         <item slot="4" amount="48" damage="3" material="leaves"/>
         <item slot="5" amount="24" material="wood"/>
         <item slot="6" material="golden apple"/>
-        <item slot="8" amount="6" material="arrow"/>
         <leggings unbreakable="true" locked="true" material="chainmail leggings">
             <enchantment level="2">projectile_protection</enchantment>
         </leggings>
@@ -191,6 +192,7 @@
 </spawns>
 <projectiles>
     <projectile id="arrow" name="crossbow bolt" velocity="4" damage="7" throwable="true" cooldown="2.5s"/>
+    <projectile id="throwable-fireball" name="fireball" projectile="Fireball" velocity=".6" click="right" power="3" damage="1" cooldown="1s"/>
 </projectiles>
 <!-- spawn region stuff  -->
 <variables>
@@ -214,10 +216,6 @@
     <variable id="team_kill_enabled" scope="match"/>
 
     <variable id="team_is_dead" scope="team">0</variable>
-    <with-team id="red_team_is_dead" var="team_is_dead" team="red-team"/>
-    <with-team id="yellow_team_is_dead" var="team_is_dead" team="yellow-team"/>
-    <with-team id="green_team_is_dead" var="team_is_dead" team="green-team"/>
-    <with-team id="blue_team_is_dead" var="team_is_dead" team="blue-team"/>
 
     <variable id="team_removal_timer" scope="team"/>
     <variable id="lowest_playercount" scope="match">0</variable>
@@ -244,11 +242,12 @@
     <timelimit id="match_timelimit"/>
     
     <!-- Player & Team Variables -->
-    <variable id="tmp_selected_team" scope="team" exclusive="1"/>
     <variable id="selected_player" scope="player" exclusive="1"/>
     <variable id="was_selected_player" scope="player"/>
     <variable id="player_identifier" scope="player" exclusive="1"/>
-    <variable id="score_cooldown" scope="player">0</variable>
+    <variable id="score_multiplier" scope="player">1</variable>
+    <variable id="calculated_damage" scope="player">1</variable>
+    <variable id="calculated_damage_display" scope="match" exclusive="1">1</variable>
     <variable id="team_damage_dealt_tracker" scope="player">0</variable>
     
     
@@ -273,6 +272,7 @@
     <players id="can-score-yellow-portal" filter="all(match-running, alive, not(team-yellow), yellow-portal, has-any-flag)"/>
     <players id="can-score-green-portal" filter="all(match-running, alive, not(team-green), green-portal, has-any-flag)"/>
     <players id="can-score-blue-portal" filter="all(match-running, alive, not(team-blue), blue-portal, has-any-flag)"/>
+    <random id="fireball-drop-chance">0.5</random>
 
     <any id="is-empty-team">
         <variable var="raw_team_playercount">0</variable>
@@ -324,6 +324,7 @@
         <material>ladder</material>
         <material>chest</material>
         <material>tnt</material>
+        <material>fire</material>
     </any>
     <any id="only-explosives">
         <material>tnt</material>
@@ -351,22 +352,7 @@
             <filter id="blue-team-alive"/>
         </all>
     </any>
-    <any id="player-scores-one-point">
-        <all id="carrying-flag-not-sudden-death">
-            <not>
-                <filter id="sudden-death-enabled"/>
-            </not>
-            <filter id="recently-had-flag"/>
-            <match-running/>
-        </all>
-        <all id="not-carrying-flag-in-sudden-death">
-            <filter id="sudden-death-enabled"/>
-            <not>
-                <filter id="recently-had-flag"/>
-            </not>
-            <match-running/> <!-- This fixes double scores somehow? -->
-        </all>
-    </any>
+
     <countdown id="recently-had-flag" duration="${flag-drop-buffer}" filter="not(has-any-flag)"/>
     <countdown id="game-countdown" duration="${match-timelimit}" message="`aTime Remaining: {0}">
         <all>
@@ -423,13 +409,13 @@
     </trigger>
     <trigger scope="team" action="kill-team">
         <filter>
-                <after duration="3s" message="Returning to OBS in: {0}"><all><filter id="team_kill_trigger = 1"/></all></after>
+                <after duration="5s" message="Returning to OBS in: {0}"><all><filter id="team_kill_trigger = 1"/></all></after>
         </filter>
     </trigger>
     <trigger scope="team" action="send-players-to-new-teams">
         <filter>
             <all>
-                <after duration="3s" message="Swapping teams in: {0}"><filter id="team_swap_trigger = 1"/></after>
+                <after duration="5s" message="Swapping teams in: {0}"><filter id="team_swap_trigger = 1"/></after>
             </all>
         </filter>
     </trigger>
@@ -451,115 +437,70 @@
     <!-- logic for teams scoring in portals & scoring messages -->
     <trigger scope="player" filter="red-portal">
         <action>
-            <set var="player_identifier" value="1"/>
-            <set var="player_identifier" value="1"/>
-            <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="red_team_lives := red_team_lives - (${score-multiplier} * ${score-amount})"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
-                <switch-scope inner="match">
-                    <message text="${score-message-double} ${red-team-alias}">
-                        <replacements>
-                            <player id="player" var="player_identifier" fallback="A player"/>
-                        </replacements>
-                    </message>
-                </switch-scope>
-            </action>
-            <action filter="player-scores-one-point">
-                <action id="red_team_lives := red_team_lives - ${score-amount}"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + ${score-amount}"/>
+            <action id="caluate-damage-dealt-to-team"/>
+            <action filter="calculated_damage=1..">
+                <set var="red_team_lives" value="red_team_lives - calculated_damage"/> 
                 <switch-scope inner="match">
                     <message text="${score-message} ${red-team-alias}">
                         <replacements>
+                            <decimal id="calcdamage"  value="calculated_damage_display"/>
                             <player id="player" var="player_identifier" fallback="A player"/>
                         </replacements>
                     </message>
                 </switch-scope>
+                <set var="notify_red_team" value="1"/>
             </action>
-            <set var="notify_red_team" value="1"/>
         </action>
     </trigger>
     <trigger scope="player" filter="yellow-portal">
         <action>
-            <set var="player_identifier" value="1"/>
-            <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="yellow_team_lives := yellow_team_lives - (${score-multiplier} * ${score-amount})"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
-                <switch-scope inner="match">
-                    <message text="${score-message-double} ${yellow-team-alias}">
-                        <replacements>
-                            <player id="player" var="player_identifier" fallback="A player"/>
-                        </replacements>
-                    </message>
-                </switch-scope>
-            </action>
-            <action filter="player-scores-one-point">
-                <action id="yellow_team_lives := yellow_team_lives - ${score-amount}"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + ${score-amount}"/>
+            <action id="caluate-damage-dealt-to-team"/>
+            <action filter="calculated_damage=1..">
+                <set var="yellow_team_lives" value="yellow_team_lives - calculated_damage"/> 
                 <switch-scope inner="match">
                     <message text="${score-message} ${yellow-team-alias}">
                         <replacements>
                             <player id="player" var="player_identifier" fallback="A player"/>
+                            <decimal id="calcdamage" value="calculated_damage_display"/>
                         </replacements>
                     </message>
                 </switch-scope>
+                <set var="notify_yellow_team" value="1"/>
             </action>
-            <set var="notify_yellow_team" value="1"/>
         </action>
     </trigger>
     <trigger scope="player" filter="green-portal">
         <action>
-            <set var="player_identifier" value="1"/>
-            <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="green_team_lives := green_team_lives - (${score-multiplier} * ${score-amount})"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
-                <switch-scope inner="match">
-                    <message text="${score-message-double} ${green-team-alias}">
-                        <replacements>
-                            <player id="player" var="player_identifier" fallback="A player"/>
-                        </replacements>
-                    </message>
-                </switch-scope>
-            </action>
-            <action filter="player-scores-one-point">
-                <action id="green_team_lives := green_team_lives - ${score-amount}"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + ${score-amount}"/>
+            <action id="caluate-damage-dealt-to-team"/>
+            <action filter="calculated_damage=1..">
+                <set var="green_team_lives" value="green_team_lives - calculated_damage"/> 
                 <switch-scope inner="match">
                     <message text="${score-message} ${green-team-alias}">
                         <replacements>
                             <player id="player" var="player_identifier" fallback="A player"/>
+                            <decimal id="calcdamage" value="calculated_damage_display"/>
                         </replacements>
                     </message>
                 </switch-scope>
+                <set var="notify_green_team" value="1"/>
             </action>
-            <set var="notify_green_team" value="1"/>
         </action>
     </trigger>
     <trigger scope="player" filter="blue-portal">
         <action>
-            <set var="player_identifier" value="1"/>
-            <action filter="all(sudden-death-enabled,recently-had-flag,match-running)">
-                <action id="blue_team_lives := blue_team_lives - (${score-multiplier} * ${score-amount})"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + (${score-multiplier} * ${score-amount})"/>
-                <switch-scope inner="match">
-                    <message text="${score-message-double} ${blue-team-alias}">
-                        <replacements>
-                            <player id="player" var="player_identifier" fallback="A player"/>
-                        </replacements>
-                    </message>
-                </switch-scope>
-            </action>
-            <action filter="player-scores-one-point">
-                <action id="blue_team_lives := blue_team_lives - ${score-amount}"/>
-                <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + ${score-amount}"/>
+            <action id="caluate-damage-dealt-to-team"/>
+            <action filter="calculated_damage=1..">
+                <set var="blue_team_lives" value="blue_team_lives - calculated_damage"/> 
                 <switch-scope inner="match">
                     <message text="${score-message} ${blue-team-alias}">
                         <replacements>
                             <player id="player" var="player_identifier" fallback="A player"/>
+                            <decimal id="calcdamage" value="calculated_damage_display"/>
                         </replacements>
                     </message>
                 </switch-scope>
+                <set var="notify_blue_team" value="1"/>
             </action>
-            <set var="notify_blue_team" value="1"/>
         </action>
     </trigger>
 
@@ -567,7 +508,20 @@
     <trigger scope="match" filter="sudden-death-enabled-2" action="notify-sudden-death-2"/>
 
      <!-- Actions -->
-
+    <action id="caluate-damage-dealt-to-team" scope="player">
+        <set var="player_identifier" value="1"/>
+        <set var="calculated_damage" value="0"/>
+        <set var="score_multiplier" value="0"/>
+        <action filter="any(recently-had-flag,has-any-flag)">
+            <set var="score_multiplier" value="score_multiplier + 1"/>
+        </action>
+        <action filter="sudden-death-enabled">
+            <set var="score_multiplier" value="score_multiplier + 1"/>
+        </action>
+        <set var="calculated_damage" value="score_multiplier * ${score-amount}"/>
+        <set var="calculated_damage_display" value="calculated_damage"/>
+        <set var="team_damage_dealt_tracker" value="team_damage_dealt_tracker + calculated_damage"/>
+    </action>
     <action id="tmp-get-team-playercounts"  scope="match">
         <switch-scope inner="team">
             <set var="tmp_team_playercount" value="0"/>
@@ -755,6 +709,9 @@
         <switch-scope inner="match">
             <action id="tmp-get-team-playercounts"/>
         </switch-scope>
+        <switch-scope inner="player">
+            <action id="was_selected_player := 0"/>
+        </switch-scope>
         <repeat times="tmp_team_playercount">
             <set var="tmp_team_playercount" value="${no-players}"/>
             <switch-scope inner="player" filter="was_selected_player=..0">
@@ -857,7 +814,7 @@
     <cuboid id="mid-room" min="-15,0,15" max="16,20,-15"/>
     <union id="spawners">
         <cuboid id="mid-spawner" min="-1,9,-1" size="3,2,3"/>
-        <cuboid id="red-blue-spawner" min="-55,6,2" size="-3,4,-3"/> <!--blue-red-->
+        <cuboid id="red-blue-spawner" min="-53,6,2" size="-3,4,-3"/> <!--blue-red-->
         <mirror normal="1,0,1" origin="0.5,0,0.5" region="red-blue-spawner" id="spawner2"/> <!--blue-green-->
         <mirror normal="1,0,0" origin="0.5,0,0.5" region="red-blue-spawner" id="spawner3"/> <!--green-yellow-->
         <mirror normal="1,0,-1" origin="0.5,0,0.5" region="red-blue-spawner" id="spawner4"/> <!--yellow-red-->
@@ -927,6 +884,8 @@
     <item>wood</item>
     <item>leaves</item>
     <item>firework charge</item>
+    <item>fireball</item>
+    <item>sapling</item>
 </itemremove>
 <itemkeep>
     <item>golden apple</item>
@@ -972,16 +931,19 @@
 </tnt>
 <lootables>
     <loot id="tnt-pool">
-        <any count="1..2" unique="false">
+        <any count="2" unique="false">
             <item material="tnt"/>
         </any>
-        <any count="2..4" unique="false">
-            <option weight="6">
-                <item material="arrow"/>
-            </option>
-            <option weight="3">
-                <item projectile="arrow" name="`rCrossbow" lore="`r`7Right-click to fire!" material="firework charge"/>
-            </option>
+        <any count="1" unique="false">
+            <maybe filter="fireball-drop-chance">
+                <item projectile="throwable-fireball" name="`6Fireball" lore="`r`7Right-click to fire!" material="fireball"/>
+            </maybe>
+        </any>
+        <any count="1..3" unique="false">
+            <item projectile="arrow" name="`rCrossbow" lore="`r`7Right-click to fire!" material="firework charge"/>
+        </any>
+        <any count="3..6" unique="false">
+            <item damage="3" material="leaves"/>
         </any>
     </loot>
     <fill loot="tnt-pool" filter="only-chests" refill-interval="10s" refill-clear="true"/>


### PR DESCRIPTION
# New
- TNT Chest Lootables have been upgraded and have a chance to contain throwable fireballs and also leaves

# Changes
- Refactored team scoring logic in an attempt to fix an inconsistent scoring bug
- Fixed a bug preventing some players from properly swapping teams if they had already done so earlier in the match
- Removed arrows from all kits & lootables
- Prevent saplings from dropping