### PR TITLE
FB: Data-Rush [Hotfix]

### DIFF
--- a/ctf/fb_data_rush/map.xml
+++ b/ctf/fb_data_rush/map.xml
@@ -2,7 +2,7 @@
 <name>FB: Data-Rush</name>
 <slug>tvt_data_rush</slug>
 <variant id="comp" override="true">FB: Super-Rush</variant>
-<version>1.2.2</version>
+<version>1.2.3</version>
 <phase>development</phase>
 <objective>Score your flag in the enemy goals, last team standing wins!</objective>
 <created>2025-11-15</created>
@@ -319,6 +319,7 @@
         <material>wooden_door</material>
         <material>wood:0</material>
         <material>wood_step:0</material>
+        <material>wood_step:8</material>
         <material>wood_double_step:0</material>
         <material>wood_stairs:0</material>
         <material>ladder</material>


### PR DESCRIPTION
- Wooden slab top half blocks specifically were unable to be broken by all players