### PR TITLE
Courtyard Isles - Set Correct Map Version

### DIFF
--- a/ctf/fb_courtyard_isles/map.xml
+++ b/ctf/fb_courtyard_isles/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <name>FB: Courtyard Isles</name>
 <variant id="comp" override="true">FB: Tourney Isles</variant>
-<version>2.0.0</version>
+<version>1.0.0</version>
 <phase>development</phase>
 <created>2025-12-29</created>
 <constants>


### PR DESCRIPTION
The map was published under V2.0.0 when it should of been V1.0.0