### PR TITLE
fix(frog_pond): correct the crafting table material name

### DIFF
--- a/dtcm/frog_pond/map.xml
+++ b/dtcm/frog_pond/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Frog Pond</name>
-<version>1.0.0</version>
+<version>1.0.1</version>
 <objective>Destroy the other team's monument!</objective>
 <created>2026-01-26</created>
 <constants>
@@ -77,10 +77,10 @@
 <filters>
     <material id="gold-block">gold block</material>
     <any id="spawn-blocks">
-        <material>crafting table</material>
+        <material>workbench</material>
         <material>chest</material>
     </any>
-    <material id="crafting-table">crafting table</material>
+    <material id="crafting-table">workbench</material>
 </filters>
 <destroyables name="Monument" materials="obsidian" show-progress="true" mode-changes="true">
     <destroyable region="blue-monument" owner="blue-team"/>


### PR DESCRIPTION
Crafting tables are way too modernpilled. The 1.8 people call them workbenches.