### PR TITLE
Sunbliss: 1.0.3

### DIFF
--- a/ctw/sunbliss/map.xml
+++ b/ctw/sunbliss/map.xml
@@ -107,6 +107,7 @@
         <material>jungle fence gate</material>
         <material>cauldron</material>
     </any>
+    <material id="sign">wall sign</material>
     <material id="redstone">redstone wire</material>
 </filters>
 <regions>
@@ -171,6 +172,10 @@
         <cuboid min="167,18,28" max="166,20,29"/>
         <cuboid min="155,18,295" max="156,20,294"/>
     </complement>
+    <union id="victory-monument-areas">
+        <cuboid min="215,9,50" max="213,20,53"/>
+        <cuboid min="107,9,273" max="109,20,270"/>
+    </union>
     <union id="interaction-protected-region">
         <region id="spawn-regions"/>
         <region id="wool-rooms-without-doors"/>
@@ -194,7 +199,8 @@
     <apply enter="red-team" region="red-spawn" message="You may not enter the enemy's spawn!"/>
     <apply enter="red-team" region="blues-wool-room" message="You may not enter your team's wool room!"/>
     <apply enter="blue-team" region="reds-wool-room" message="You may not enter your team's wool room!"/>
-    <apply block-place="only-iron-renew" block-break="only-iron" region="spawn-regions" message="You may only break iron blocks in the spawn!"/>
+    <apply enter="never" block="never" region="victory-monument-areas" message="You may not obstruct or modify the victory monument!"/>
+    <apply block-place="only-iron-renew" block-break="any(only-iron,sign)" region="spawn-regions" message="You may only break iron blocks in the spawn!"/>
     <apply block-place="never" region="build-limit">
         <message>{"translate":"match.maxBuildHeight"}</message>
     </apply>


### PR DESCRIPTION
All changes have been tested on local servers to ensure compatibility.

- Cobwebs and redstone in the wool room are no longer destroyed by flowing water

- Redstone torches can now be placed in the wool room
At the same time, door-type blocks and blocks designated as decoration items are no longer interactable in the wool room (with `apply use` and `apply block-physics` applied)

- Interaction with decoration items has also been disabled in the spawn region

- Breaking coal ore no longer drops experience

- XML cleanup and simplification

=== February 8, 2026 Additional changes ===

- Signs attached to iron blocks can now be broken in the spawn region

- Player interference with wool placement at the victory monument has been prevented