### PR TITLE
Gemetric Domination 1.3.4

### DIFF
--- a/ctw/geometric_domination/map.xml
+++ b/ctw/geometric_domination/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.5.0">
 <name>Geometric Domination</name>
 <include id="gapple-kill-reward"/>
-<version>1.3.3</version>
+<version>1.3.4</version>
 <objective>Collect the enemy's wool and return it to your monument!</objective>
 <gamemode>ctw</gamemode>
 <created>2023-01-21</created>
@@ -30,6 +30,7 @@
         </item>
         <item slot="3" unbreakable="true" material="iron axe"/>
         <item slot="4" team-color="true" amount="64" material="stained clay"/>
+        <item slot="5" material="water bucket"/>
         <item slot="22" team-color="true" amount="64" material="stained clay"/>
         <item slot="31" team-color="true" amount="64" material="stained clay"/>
         <item slot="17" material="arrow"/>
@@ -79,7 +80,6 @@
         <kit id="upgrade-kit-1">
             <item material="water bucket"/>
             <item material="water bucket"/>
-            <item material="water bucket"/>
             <item amount="24" material="ender stone"/>
             <item amount="64" material="smooth stairs"/>
             <item amount="24" material="nether brick"/>
@@ -94,7 +94,6 @@
     </give>
     <give filter="apply-kit-upgrade-2">
         <kit>
-            <item material="water bucket"/>
             <item material="water bucket"/>
             <item material="water bucket"/>
             <item amount="24" material="ender stone"/>
@@ -733,3 +732,4 @@
 </renewables>
 <maxbuildheight>22</maxbuildheight>
 </map>
+


### PR DESCRIPTION
- Add water buckets to the default kit
It's a TNT map so this change is justified
- Removed a water bucket from the extra items perk to counteract this change