### PR TITLE
Burning Palace 1.0.4

### DIFF
--- a/koth/burning_palace/map.xml
+++ b/koth/burning_palace/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0">
 <name>Burning Palace</name>
-<version>1.0.3</version>
+<version>1.0.4</version>
 <created>2026-01-17</created>
 <constant id="score">750</constant>
 <constant id="respawn-timer">3s</constant>
@@ -157,8 +157,5 @@
 <score>
     <limit>${score}</limit>
 </score>
-<disabledamage>
-    <damage>fall</damage>
-</disabledamage>
 <modifybowprojectile pickup-filter="never"/>
 </map>


### PR DESCRIPTION
- Enabled fall damage
Without fall damage it's much to easy to traverse the map and there's very little punishment for if players rush the side gardens form the bridges or while camping in the volcano launchpad. This changes should reward player that have cautious/better positioning while providing more value from the sniper towers for those who manage to knock players off the high-ground