### PR TITLE
Sunbliss: 1.0.5

### DIFF
--- a/ctw/sunbliss/map.xml
+++ b/ctw/sunbliss/map.xml
@@ -233,6 +233,7 @@
     </kill-reward>
 </kill-rewards>
 <gamerules>
+    <!-- Temporary workaround to prevent leaf decay. The map file itself must be updated to resolve the root cause -->
     <randomTickSpeed>0</randomTickSpeed>
 </gamerules>
 <hunger>


### PR DESCRIPTION
All changes have been tested on local servers to ensure compatibility.

- Set `randomTickSpeed` to 0 to prevent leaves from decaying, and added long grass and seeds to `itemremove`
- Restricted `itemkeep` planks (wood) to oak planks (wood:0)
- Refactored and simplified XML expressions and region structure