### PR TITLE
Update stained glass item to include team color

### DIFF
--- a/dtcm/little_roses/map.xml
+++ b/dtcm/little_roses/map.xml
@@ -159,7 +159,7 @@
 <kill-rewards>
     <kill-reward>
         <item material="wood" damage="2" amount="8"/>
-        <item material="stained glass" amount="8"/>
+        <item team-color="true" material="stained glass" amount="8"/>
     </kill-reward>
 </kill-rewards>
 </map>


### PR DESCRIPTION
Fixed line 162 where kill rewards give white stained glass instead of player's team colored glass.