### PR TITLE
Vauxite: Replaced void filter with inline filters

### DIFF
--- a/ctw/vauxite/map.xml
+++ b/ctw/vauxite/map.xml
@@ -57,9 +57,6 @@
 <filters>
     <team id="only-red">red</team>
     <team id="only-blue">blue</team>
-    <not id="no-void">
-        <void id="is-void"/>
-    </not>
     <not id="not-red">
         <filter id="only-red"/>
     </not>
@@ -160,7 +157,7 @@
     <apply enter="not-red" region="reds-woolrooms" message="You may not enter your own wool room!"/>
     <apply block="reds-woolrooms-filter" region="reds-woolrooms" message="You may not edit the wool room!"/>
     <apply block-place="only-iron-cause-world" block-break="only-iron" region="spawns" message="You may not edit spawn!"/>
-    <apply block="no-void" region="not-build-area" message="You may not edit the void!"/>
+    <apply block="deny(void)" region="not-build-area" message="You may not edit the void!"/>
 </regions>
 <spawners>
     <spawner spawn-region="green-wool-spawn" player-region="green-wool" delay="1.5s">


### PR DESCRIPTION
Replaced 'no-void' filter with 'deny(void)' for build area restrictions to make it more readable.