### PR TITLE
Querelous: Updated clay to match team color

### DIFF
--- a/dtcm/querelous/map.xml
+++ b/dtcm/querelous/map.xml
@@ -1,6 +1,6 @@
 <map proto="1.5.0"> <!-- License: This map is available under CC-4.0-BY-SA -->
 <name>Querelous</name>
-<version>1.0.2</version>
+<version>1.0.3</version>
 <objective>Leak the core and break the monument!</objective>
 <created>2023-07-02</created>
 <include id="gapple-kill-reward"/>
@@ -20,10 +20,10 @@
         <item slot="1" unbreakable="true" enchantment="arrow infinite" material="bow"/>
         <item slot="28" material="arrow"/>
         <item slot="3" amount="32" material="nether fence"/>
-        <item slot="2" damage="11" amount="64" material="stained clay"/>
-        <item slot="29" damage="11" amount="64" material="stained clay"/>
-        <item slot="20" damage="11" amount="64" material="stained clay"/>
-        <item slot="11" damage="11" amount="64" material="stained clay"/>
+        <item slot="2" team-color="true" amount="64" material="stained clay"/>
+        <item slot="29" team-color="true" amount="64" material="stained clay"/>
+        <item slot="20" team-color="true" amount="64" material="stained clay"/>
+        <item slot="11" team-color="true" amount="64" material="stained clay"/>
         <item slot="30" amount="32" material="step"/>
         <item slot="21" amount="32" material="ladder"/>
         <item slot="4" amount="16" material="stone button"/>


### PR DESCRIPTION
- Added "team-color" attribute to remove in-game confusion caused by all players having the same colored block.