### PR TITLE
Up Down Fly: Update map creation date

### DIFF
--- a/arcade/standard/up_down_fly/map.xml
+++ b/arcade/standard/up_down_fly/map.xml
@@ -2,7 +2,7 @@
 <game>Progress</game>
 <name>Up Down Fly</name>
 <version>1.0.1</version>
-<created>2026-08-08</created>
+<created>2026-07-31</created>
 <objective>Be the first to finish the parkour!</objective>
 <phase>staging</phase>
 <authors>


### PR DESCRIPTION
The previous creation date was incorrect, so it was changed to reflect the accurate release date of the map.